### PR TITLE
Pre-mainnet hardening: tx simulation + Math.round + stale callback fix

### DIFF
--- a/src/hooks/useCreateMarket.ts
+++ b/src/hooks/useCreateMarket.ts
@@ -104,7 +104,7 @@ export function useCreateMarket() {
             oracle: params.oracle.trim() || undefined,
             max_leverage: params.maxLeverage,
             funding_rate_bps: Math.round(params.fundingRate * 100),
-            insurance_amount: params.insurance * 1_000_000, // Convert to lamport-scale
+            insurance_amount: Math.round(params.insurance * 1_000_000), // Convert to lamport-scale (rounded to avoid fractional lamports)
             maker_fee_bps: Math.round(params.makerFee * 100),
             taker_fee_bps: Math.round(params.takerFee * 100),
             mode: params.mode,
@@ -136,6 +136,29 @@ export function useCreateMarket() {
             }
             return bytes;
           });
+
+          // Step 2a: Simulate transactions before signing to catch errors early
+          setState((s) => ({
+            ...s,
+            step: 'Simulating transaction…',
+          }));
+
+          for (let i = 0; i < txBytes.length; i++) {
+            const tx = Transaction.from(txBytes[i]);
+            const sim = await connection.simulateTransaction(tx);
+            if (sim.value.err) {
+              const logs = sim.value.logs?.join('\n') ?? '';
+              throw new Error(
+                `Transaction ${i + 1} simulation failed: ${JSON.stringify(sim.value.err)}${logs ? `\nLogs:\n${logs}` : ''}`,
+              );
+            }
+          }
+
+          // Step 2b: Sign and send via MWA
+          setState((s) => ({
+            ...s,
+            step: 'Sign in your wallet…',
+          }));
 
           const { signatures } = await signAndSend(txBytes);
 

--- a/src/hooks/usePriceHistory.ts
+++ b/src/hooks/usePriceHistory.ts
@@ -23,12 +23,13 @@ export function usePriceHistory(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasFetchedRef = useRef(false);
 
   const fetchPrices = useCallback(async () => {
     if (!slabAddress) return;
 
     try {
-      setLoading((prev) => (prices.length === 0 ? true : prev)); // Only show loading on first fetch
+      if (!hasFetchedRef.current) setLoading(true); // Only show loading on first fetch
       const data = await api.getPriceHistory(slabAddress);
 
       if (data && data.length > 0) {
@@ -39,6 +40,7 @@ export function usePriceHistory(
         );
         setPrices(sorted.map((d) => d.last_price));
         setError(null);
+        hasFetchedRef.current = true;
       }
     } catch (err) {
       const msg =
@@ -47,15 +49,17 @@ export function usePriceHistory(
     } finally {
       setLoading(false);
     }
-  }, [slabAddress, prices.length]);
+  }, [slabAddress]);
 
   useEffect(() => {
     if (!slabAddress) {
       setPrices([]);
       setError(null);
+      hasFetchedRef.current = false;
       return;
     }
 
+    hasFetchedRef.current = false;
     fetchPrices();
 
     // Poll every 30s
@@ -67,7 +71,7 @@ export function usePriceHistory(
         intervalRef.current = null;
       }
     };
-  }, [slabAddress]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [slabAddress, fetchPrices]);
 
   const refresh = useCallback(() => {
     fetchPrices();


### PR DESCRIPTION
## Pre-mainnet items flagged by QA and Security

### 1. Transaction simulation before MWA signing
- Simulates all unsigned transactions against the RPC before prompting the user's wallet
- Catches on-chain errors early (insufficient funds, invalid accounts, etc.)
- Displays simulation step in the progress UI
- Includes program logs in error messages for debugging

### 2. Math.round() for insurance_amount
- `params.insurance * 1_000_000` can produce floating point artifacts (e.g. `0.1 * 1_000_000 = 100000.00000000001`)
- Wrapped with `Math.round()` to ensure integer lamport values

### 3. usePriceHistory stale callback fix (QA P3)
- `fetchPrices` had `prices.length` in deps causing identity changes, but the interval captured the old reference
- Replaced with a `hasFetchedRef` to track first-fetch loading state
- Removed `eslint-disable` comment, proper exhaustive deps now

### Files changed
- `src/hooks/useCreateMarket.ts` — simulation + Math.round
- `src/hooks/usePriceHistory.ts` — stale callback fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced error detection for market creation by pre-validating transactions before wallet signature requests, preventing failed signing attempts
- Improved loading state behavior for price history data with accurate first-load indicators
- Refined insurance amount calculations for increased precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->