### PR TITLE
PERC-150: Add detailed README + Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,81 +1,215 @@
 # Percolator Mobile
 
-Solana Seeker native trading app — React Native + Expo bare workflow.
+Native Solana trading app for the [Percolator](https://github.com/dcccrypto/percolator) perpetual futures protocol — built for the **Solana Seeker** phone with Mobile Wallet Adapter (MWA) integration.
 
-## Stack
+> **⚠️ DISCLAIMER: FOR EDUCATIONAL PURPOSES ONLY** — This code has NOT been audited. Do NOT use in production or with real funds.
 
-- **React Native** 0.81 + **Expo** 54 (bare workflow)
-- **Solana Mobile Stack** — Mobile Wallet Adapter (MWA) for Seed Vault signing
-- **@solana/web3.js** — Solana transaction building
-- **React Navigation** — Bottom tab navigation
-- **Supabase** — Backend data
-- **Zustand** — State management
-- **NativeWind** — Tailwind CSS for React Native
+---
+
+## What It Does
+
+Trade coin-margined perpetuals on Solana from your phone. Connect your wallet via biometric signing (fingerprint on Seeker), view live markets, manage positions, and deposit/withdraw collateral — all natively, no browser required.
+
+**Key features:**
+- **One-tap wallet connect** via Mobile Wallet Adapter (Seed Vault, Phantom, Solflare)
+- **Biometric signing** — no seed phrases, no popups
+- **Live market data** from on-chain slab accounts and DEX oracles
+- **Position management** — open/close longs and shorts with leverage
+- **Portfolio view** — real-time PnL, collateral, and liquidation prices
+- **Terminal/HUD aesthetic** — matches the percolatorlaunch.com design system
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│           Percolator Mobile             │
+│                                         │
+│  React Native 0.81 + Expo 54 (bare)    │
+│                                         │
+│  ┌───────────┐  ┌───────────────────┐   │
+│  │ Screens   │  │ Solana Connection │   │
+│  │ - Trade   │  │ @solana/web3.js   │   │
+│  │ - Markets │  │                   │   │
+│  │ - Folio   │  │ MWA (biometric)   │   │
+│  │ - Settings│  │ Seed Vault / etc  │   │
+│  └───────────┘  └───────────────────┘   │
+│         │                 │             │
+│    Supabase          Solana RPC         │
+│    (backend)         (devnet/mainnet)   │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | [React Native](https://reactnative.dev) 0.81 + [Expo](https://expo.dev) 54 (bare workflow) |
+| Language | TypeScript (strict mode) |
+| Wallet | [Solana Mobile Stack](https://solanamobile.com) — Mobile Wallet Adapter (MWA) |
+| Blockchain | [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) |
+| Navigation | [React Navigation](https://reactnavigation.org/) (bottom tabs) |
+| State | [Zustand](https://zustand-demo.pmnd.rs/) |
+| Styling | [NativeWind](https://www.nativewind.dev/) (Tailwind CSS for React Native) |
+| Backend | [Supabase](https://supabase.com) |
+
+---
 
 ## Prerequisites
 
-- Node.js 18+
-- Android SDK / Android Studio
-- Java 17+ (for Android builds)
-- Expo CLI: `npm install -g expo-cli`
-- EAS CLI: `npm install -g eas-cli` (for builds)
+- **Node.js** 18+ and npm
+- **Android Studio** with Android SDK (API 33+)
+- **Java** 17+ (for Android builds)
+- **Expo CLI**: `npm install -g expo-cli`
+- **EAS CLI**: `npm install -g eas-cli` (for production builds)
+- Optionally: a **Solana Seeker** device or Android emulator with a wallet app
 
-## Setup
+---
+
+## Getting Started
+
+### Clone and Install
 
 ```bash
-# Clone
 git clone https://github.com/dcccrypto/percolator-mobile.git
 cd percolator-mobile
-
-# Install
 npm install
+```
 
-# Configure environment
+### Configure Environment
+
+```bash
 cp .env.example .env
-# Edit .env with your RPC URL and Supabase credentials
+```
 
+Edit `.env` with your configuration:
+
+```env
+SOLANA_RPC_URL=https://api.devnet.solana.com
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+```
+
+### Run Development Build
+
+```bash
 # Start Metro bundler
 npx expo start --dev-client
 
-# Run on Android (requires emulator or device)
+# Run on Android device/emulator
 npx expo run:android
+
+# Run on iOS simulator (macOS only)
+npx expo run:ios
 ```
+
+### Build for Production
+
+```bash
+# Android APK (for dApp Store / sideloading)
+eas build --platform android --profile production
+
+# Android AAB (for Play Store)
+eas build --platform android --profile play-store
+```
+
+---
 
 ## Project Structure
 
 ```
-src/
-├── navigation/     # React Navigation setup
-├── screens/        # Screen components (Trade, Portfolio, Markets, Settings)
-├── components/
-│   ├── ui/         # Shared primitives (Panel, HudCorners)
-│   └── trade/      # Trading-specific components
-├── hooks/          # Custom hooks (useMWA, useTrading)
-├── lib/            # Solana connection, Supabase client, constants
-├── theme/          # Design tokens matching percolatorlaunch.com
-└── types/          # TypeScript types
+percolator-mobile/
+├── src/
+│   ├── navigation/         # React Navigation setup (bottom tabs)
+│   ├── screens/            # Screen components
+│   │   ├── TradeScreen.tsx      # Main trading interface
+│   │   ├── MarketsScreen.tsx    # Browse available markets
+│   │   ├── PortfolioScreen.tsx  # Positions, PnL, collateral
+│   │   └── SettingsScreen.tsx   # RPC, wallet, preferences
+│   ├── components/
+│   │   ├── ui/             # Shared primitives (Panel, HudCorners, Button)
+│   │   └── trade/          # Trading-specific (OrderForm, PositionCard, PriceChart)
+│   ├── hooks/
+│   │   ├── useMWA.ts       # Mobile Wallet Adapter connection
+│   │   └── useTrading.ts   # Trade execution and position management
+│   ├── lib/
+│   │   ├── solana.ts       # Solana connection + transaction helpers
+│   │   ├── supabase.ts     # Supabase client
+│   │   └── constants.ts    # Program IDs, endpoints, config
+│   ├── theme/              # Design tokens (matches percolatorlaunch.com)
+│   └── types/              # TypeScript type definitions
+├── android/                # Native Android project
+├── ios/                    # Native iOS project
+├── App.tsx                 # Root component
+├── app.json                # Expo configuration
+├── metro.config.js         # Metro bundler config
+├── babel.config.js         # Babel config (NativeWind)
+├── tsconfig.json           # TypeScript config
+└── package.json
 ```
+
+---
 
 ## Design System
 
-Uses the same design tokens as `percolatorlaunch.com`:
-- Dark theme (`#0A0A0F` background)
-- Solana purple accent (`#9945FF`)
-- JetBrains Mono monospace-first typography
-- Terminal/HUD aesthetic with sharp corners
-- Green for long positions (`#14F195`), Red for short (`#FF3B5C`)
+The app uses the same design tokens as [percolatorlaunch.com](https://percolatorlaunch.com):
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Background | `#0A0A0F` | App background |
+| Surface | `#12121A` | Card/panel backgrounds |
+| Accent | `#9945FF` | Solana purple — buttons, links |
+| Long | `#14F195` | Long positions, positive PnL |
+| Short | `#FF3B5C` | Short positions, negative PnL |
+| Font | JetBrains Mono | Monospace-first typography |
+| Corners | Sharp (0 radius) | Terminal/HUD aesthetic |
+
+---
 
 ## Wallet Integration
 
-Uses Mobile Wallet Adapter (MWA) protocol to connect with on-device wallets
-(Seed Vault Wallet on Seeker, Phantom, Solflare, etc.). All transaction signing
-is biometric (fingerprint) — no popups or seed phrases.
+The app uses the **Mobile Wallet Adapter (MWA)** protocol:
 
-## dApp Store Publishing
+1. User taps "Connect Wallet"
+2. MWA discovers on-device wallets (Seed Vault on Seeker, Phantom, Solflare)
+3. User selects wallet and authorizes with biometrics
+4. All subsequent transaction signing uses biometric confirmation — no popups or seed phrases
 
-See the `solana-seeker-mobile` skill reference for full dApp Store publishing checklist.
+```typescript
+import { useMWA } from "./hooks/useMWA";
 
-```bash
-# Build production APK
-eas build --platform android --profile production
+const { connect, signTransaction, publicKey } = useMWA();
+await connect();
+const signedTx = await signTransaction(transaction);
 ```
+
+---
+
+## Solana Seeker dApp Store Publishing
+
+For publishing to the Solana dApp Store:
+
+1. Build production APK: `eas build --platform android --profile production`
+2. Follow the [Solana dApp Store submission guide](https://docs.solanamobile.com/dapp-publishing/intro)
+3. Ensure the app meets dApp Store listing requirements (icon, screenshots, description)
+
+---
+
+## Related Repositories
+
+| Repository | Description |
+|-----------|-------------|
+| [percolator](https://github.com/dcccrypto/percolator) | Core risk engine crate (Rust) |
+| [percolator-prog](https://github.com/dcccrypto/percolator-prog) | Solana on-chain program (wrapper) |
+| [percolator-matcher](https://github.com/dcccrypto/percolator-matcher) | Reference matcher program for LP pricing |
+| [percolator-stake](https://github.com/dcccrypto/percolator-stake) | Insurance LP staking program |
+| [percolator-sdk](https://github.com/dcccrypto/percolator-sdk) | TypeScript SDK for client integration |
+| [percolator-ops](https://github.com/dcccrypto/percolator-ops) | Operations dashboard |
+| [percolator-launch](https://github.com/dcccrypto/percolator-launch) | Full-stack launch platform (monorepo) |
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## PERC-150: Add detailed README + Apache 2.0 license

### Changes
- **README.md**: Comprehensive documentation with architecture diagrams, setup instructions, build/test commands, deployment notes, and cross-links to all related Percolator repositories
- **LICENSE**: Apache 2.0 license file (where missing)
- **Related Repositories**: Cross-linking table connecting all 8 project repos

### Repos covered (8 total)
- percolator (core risk engine)
- percolator-prog (Solana program)
- percolator-matcher (reference matcher)
- percolator-stake (insurance staking)
- percolator-sdk (TypeScript SDK)
- percolator-ops (operations dashboard)
- percolator-mobile (Solana Seeker app)
- percolator-launch (full-stack monorepo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completely revamped README with detailed setup instructions, architecture overview, design system documentation, wallet integration guidance, and feature descriptions to help users get started with the Solana trading application.

* **Chores**
  * Added Apache License 2.0 to the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->