### PR TITLE
fix(PERC-207): remove stale SYSVAR_CLOCK_PUBKEY from TradeCpi accounts

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -363,11 +363,11 @@ function buildTradeCpiIx(
     encU16LE(userIdx),
     encI128LE(sizeE6),
   );
+  // 7 accounts after PERC-199 (Clock::get() syscall replaces clock sysvar)
   return buildIx(programId, [
     meta(user, true, true),
     meta(lpOwner, false, false),
     meta(slab, false, true),
-    meta(SYSVAR_CLOCK_PUBKEY, false, false),
     meta(oracle, false, false),
     meta(matcherProg, false, false),
     meta(matcherCtx, false, true),


### PR DESCRIPTION
## Summary

**PERC-207** — Fix stale TradeCpi accounts (HIGH severity finding from PERC-206 security audit).

## Problem

Commit `8e46e38` (PERC-199) optimized the on-chain program to use `Clock::get()` syscall instead of `Clock::from_account_info()`, reducing TradeCpi from **8 → 7** accounts by removing the clock sysvar account. The mobile app's `buildTradeCpiIx()` was not updated, leaving `SYSVAR_CLOCK_PUBKEY` at position 3 in the accounts array.

This mismatch would cause **all mobile trades to fail** after the program is deployed.

## Fix

Remove `SYSVAR_CLOCK_PUBKEY` from the `buildTradeCpiIx()` accounts array in `src/hooks/useTrade.ts` (8 → 7 accounts).

Other instructions (`DepositCollateral`, `WithdrawCollateral`, `KeeperCrank`) still use clock sysvar and are **not affected** by PERC-199.

## Testing

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Account ordering verified against on-chain program PERC-199 commit

Closes #10