### PR TITLE
fix: remove clock sysvar from TradeCpi accounts (PERC-207)

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -363,11 +363,11 @@ function buildTradeCpiIx(
     encU16LE(userIdx),
     encI128LE(sizeE6),
   );
+  // 7 accounts (PERC-199/207: clock sysvar removed — program uses Clock::get() syscall)
   return buildIx(programId, [
     meta(user, true, true),
     meta(lpOwner, false, false),
     meta(slab, false, true),
-    meta(SYSVAR_CLOCK_PUBKEY, false, false),
     meta(oracle, false, false),
     meta(matcherProg, false, false),
     meta(matcherCtx, false, true),


### PR DESCRIPTION
## What
Remove stale `SYSVAR_CLOCK_PUBKEY` from `buildTradeCpiIx()` accounts array.

## Why
PR #449 on percolator-launch removed clock from TradeCpi (8→7 accounts) as the program now uses `Clock::get()` syscall. The mobile app still passed clock at position 4, which would cause **all mobile trades to fail** after program deploy.

## Changes
- `src/hooks/useTrade.ts`: Remove `SYSVAR_CLOCK_PUBKEY` meta from `buildTradeCpiIx()` (position 4)
- Other instructions (Deposit, Withdraw, KeeperCrank) still use clock — unchanged

## Testing
- TSC passes clean (`npx tsc --noEmit`)
- Account layout now matches `ACCOUNTS_TRADE_CPI` in `packages/core/src/abi/accounts.ts` (7 accounts)

Fixes PERC-207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized trade instruction handling by removing unnecessary account parameters, improving performance and reliability of trading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->