### PR TITLE
fix(android): fix applicationId mismatch — com.percolatormobile → com.percolator.seeker

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,11 +89,11 @@ android {
 
     namespace "com.percolatormobile"
     defaultConfig {
-        applicationId "com.percolatormobile"
+        applicationId "com.percolator.seeker"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">percolator-mobile</string>
+    <string name="app_name">Percolator</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "percolator-mobile",
     "slug": "percolator-mobile",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -16,7 +16,7 @@
     },
     "android": {
       "package": "com.percolator.seeker",
-      "versionCode": 1,
+      "versionCode": 2,
       "minSdkVersion": 24,
       "targetSdkVersion": 34,
       "adaptiveIcon": {


### PR DESCRIPTION
## Problem
APK installs with "invalid package" error on Android.

**Root cause:** `applicationId` in `android/app/build.gradle` was `com.percolatormobile` but `app.json` specifies `android.package = com.percolator.seeker`. This mismatch causes Android to reject the APK.

## Changes
| File | Change |
|------|--------|
| `android/app/build.gradle` | `applicationId` `com.percolatormobile` → `com.percolator.seeker` |
| `android/app/build.gradle` | `versionCode` 1→2, `versionName` 1.0→1.0.1 |
| `android/app/src/main/res/values/strings.xml` | app_name `percolator-mobile` → `Percolator` |
| `app.json` | version 1.0.0→1.0.1, android.versionCode 1→2 |

**Note:** `namespace` stays as `com.percolatormobile` — Java/Kotlin source files are unchanged. Namespace and applicationId can differ in Android.

## Testing
Build a debug APK and install:
```bash
cd android && ./gradlew assembleDebug
adb install app/build/outputs/apk/debug/app-debug.apk
```

Closes #15 (superseded by this — DISTRIBUTION.md is still valid but the build issue is now fixed at source)

🔧 Fixes the v1.0.0 broken APK release