### PR TITLE
fix(ci): add contents: write permission to build-release job

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem
The `build-release` job failed at the `Create GitHub Release` step because `GITHUB_TOKEN` lacked `contents: write` permission.

## Fix
Added `permissions: contents: write` to the `build-release` job.

## Testing
Re-tagging `v1.0.1` after merging will verify the release creation succeeds.

## Checklist
- [x] CI fix only — no app code changed
- [x] Permission scoped to the specific job, not the entire workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration to improve release process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->