### PR TITLE
feat(PERC-427): Mobile OI bar labels + onboarding SVG icons

### DIFF
--- a/src/components/icons/OnboardingIcon.tsx
+++ b/src/components/icons/OnboardingIcon.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Svg, { Path, Circle, Ellipse } from 'react-native-svg';
+import { colors } from '../../theme/tokens';
+
+type IconType = 'perps' | 'onchain' | 'deploy';
+
+interface OnboardingIconProps {
+  type: IconType;
+  size?: number;
+}
+
+export function OnboardingIcon({ type, size = 72 }: OnboardingIconProps) {
+  if (type === 'perps') {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+        <Circle cx="32" cy="32" r="24" stroke={colors.cyan}
+          strokeWidth={1.5} strokeDasharray="40 30"
+          strokeLinecap="round" opacity={0.4} />
+        <Circle cx="32" cy="32" r="18" fill={colors.cyan} opacity={0.06} />
+        <Path d="M36 8 L22 34 H31 L28 56 L46 28 H36 L40 8 Z"
+          fill={colors.cyan} opacity={0.9} />
+        <Path d="M36 14 L27 32 H33 L30 46 L41 30 H35 L38 14 Z"
+          fill={colors.accent} opacity={0.6} />
+      </Svg>
+    );
+  }
+
+  if (type === 'onchain') {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+        <Ellipse cx="32" cy="32" rx="22" ry="16" fill={colors.accent} opacity={0.05} />
+        <Path d="M12 32 L20 18 L36 18 L44 32 L36 46 L20 46 Z"
+          stroke={colors.accent} strokeWidth={1.5}
+          fill="rgba(124,58,237,0.08)" strokeLinejoin="round" />
+        <Path d="M28 32 L36 18 L52 18 L60 32 L52 46 L36 46 Z"
+          stroke={colors.cyan} strokeWidth={1.5}
+          fill="rgba(34,211,238,0.08)" strokeLinejoin="round" />
+        <Path d="M36 22 L40 32 L36 42" stroke={colors.cyan}
+          strokeWidth={2} strokeLinecap="round" opacity={0.7} />
+        <Path d="M28 22 L24 32 L28 42" stroke={colors.accent}
+          strokeWidth={2} strokeLinecap="round" opacity={0.7} />
+      </Svg>
+    );
+  }
+
+  // deploy
+  return (
+    <Svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+      <Ellipse cx="32" cy="48" rx="6" ry="10" fill={colors.accent} opacity={0.2} />
+      <Path d="M28 46 Q32 54 36 46" stroke={colors.accent}
+        strokeWidth={2} strokeLinecap="round" opacity={0.6} />
+      <Path d="M30 48 Q32 58 34 48" stroke={colors.cyan}
+        strokeWidth={1.5} strokeLinecap="round" opacity={0.4} />
+      <Path d="M32 8 C32 8 22 22 22 36 L32 40 L42 36 C42 22 32 8 32 8 Z"
+        fill={colors.cyan} opacity={0.9} />
+      <Circle cx="32" cy="28" r="5" fill="#06060c" opacity={0.8} />
+      <Circle cx="32" cy="28" r="3" fill={colors.accent} opacity={0.9} />
+      <Circle cx="30.5" cy="26.5" r="1" fill="white" opacity={0.5} />
+      <Path d="M22 36 L16 44 L24 40 Z" fill={colors.accent} opacity={0.7} />
+      <Path d="M42 36 L48 44 L40 40 Z" fill={colors.accent} opacity={0.7} />
+    </Svg>
+  );
+}

--- a/src/screens/MarketsScreen.tsx
+++ b/src/screens/MarketsScreen.tsx
@@ -52,7 +52,12 @@ function MarketCard({
 }) {
   const changeColor = market.change24h >= 0 ? colors.long : colors.short;
   const changePrefix = market.change24h >= 0 ? '+' : '';
-  const oiPct = Math.min((market.totalOpenInterest ?? 0) / 5_000_000, 1);
+  const maxOi = (market as any).maxOpenInterest ?? 5_000_000;
+  const oiPct = Math.min((market.totalOpenInterest ?? 0) / maxOi, 1);
+  const oiFillColor =
+    oiPct < 0.5 ? colors.accent :
+    oiPct < 0.8 ? colors.warning :
+    colors.short;
 
   return (
     <Panel style={styles.card}>
@@ -71,8 +76,12 @@ function MarketCard({
         <Text style={styles.leverage}>{market.maxLeverage}x max</Text>
       </View>
 
+      <View style={styles.oiLabelRow}>
+        <Text style={styles.oiLabel}>OI Utilization</Text>
+        <Text style={styles.oiPctText}>{Math.round(oiPct * 100)}%</Text>
+      </View>
       <View style={styles.oiBar}>
-        <View style={[styles.oiFill, { width: `${oiPct * 100}%` }]} />
+        <View style={[styles.oiFill, { width: `${oiPct * 100}%`, backgroundColor: oiFillColor }]} />
       </View>
 
       <View style={styles.tradeRow}>
@@ -301,6 +310,24 @@ const styles = StyleSheet.create({
     fontFamily: fonts.mono,
     fontSize: 11,
     color: colors.textMuted,
+  },
+  oiLabelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  oiLabel: {
+    fontFamily: fonts.body,
+    fontSize: 10,
+    color: colors.textMuted,
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  oiPctText: {
+    fontFamily: fonts.body,
+    fontSize: 10,
+    color: colors.textSecondary,
   },
   oiBar: {
     height: 4,

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { colors, radii } from '../theme/tokens';
 import { fonts } from '../theme/fonts';
 import { useMWA } from '../hooks/useMWA';
+import { OnboardingIcon } from '../components/icons/OnboardingIcon';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -18,17 +19,17 @@ const SLIDES = [
   {
     title: 'Permissionless Perps\non Solana',
     subtitle: 'Trade any asset with leverage. No gatekeepers. No KYC.',
-    icon: '⚡',
+    icon: 'perps' as const,
   },
   {
     title: 'Fully On-Chain',
     subtitle: 'Every trade, every position — verifiable on Solana.',
-    icon: '🔗',
+    icon: 'onchain' as const,
   },
   {
     title: 'Deploy in 60s',
     subtitle: 'Create your own perpetual market in under a minute.',
-    icon: '🚀',
+    icon: 'deploy' as const,
   },
 ];
 
@@ -102,7 +103,9 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         keyExtractor={(_, i) => String(i)}
         renderItem={({ item }) => (
           <View style={[styles.slide, { width: SCREEN_WIDTH }]}>
-            <Text style={styles.slideIcon}>{item.icon}</Text>
+            <View style={styles.slideIconWrap}>
+              <OnboardingIcon type={item.icon} size={72} />
+            </View>
             <Text style={styles.slideTitle}>{item.title}</Text>
             <Text style={styles.slideSubtitle}>{item.subtitle}</Text>
           </View>
@@ -142,9 +145,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 40,
   },
-  slideIcon: {
-    fontSize: 64,
+  slideIconWrap: {
     marginBottom: 24,
+    alignItems: 'center' as const,
   },
   slideTitle: {
     fontFamily: fonts.display,


### PR DESCRIPTION
## What
Two visual improvements for the mobile app per designer spec.

### Part A — OI Utilization Label (MarketCard)
- Added inline label row ('OI Utilization' + percentage) above the OI progress bar
- Dynamic fill color based on utilization thresholds:
  - Purple (accent) < 50%
  - Amber (warning) 50–80%  
  - Red (short) > 80%
- Uses `market.maxOpenInterest ?? 5_000_000` for cap

### Part B — Onboarding SVG Icons
- Replaced emoji icons (⚡🔗🚀) with brand SVG marks via `react-native-svg`
- New `OnboardingIcon` component with 3 icon types: perps, onchain, deploy
- 72dp consistent sizing across Android/iOS (no platform emoji variance)
- Uses brand colors (cyan #14F195, purple #9945FF)

## How to test
1. Markets screen: OI bar should show 'OI UTILIZATION' label + percentage
2. OI bar fill color changes: purple→amber→red based on utilization
3. Onboarding: three slides show SVG icons instead of emoji
4. Verify icons render identically on Android and iOS