### PR TITLE
fix(PERC-427): update OnboardingScreen test to use testID instead of emoji text (#30)

### DIFF
--- a/__tests__/screens/OnboardingScreen.test.tsx
+++ b/__tests__/screens/OnboardingScreen.test.tsx
@@ -52,10 +52,11 @@ describe('OnboardingScreen', () => {
   });
 
   it('renders slide icons', () => {
-    const { getByText } = render(
+    const { getByTestId } = render(
       <OnboardingScreen onComplete={mockOnComplete} />,
     );
-    expect(getByText('⚡')).toBeTruthy();
+    // Slide icons are SVG components (OnboardingIcon) since PERC-427 replaced emoji
+    expect(getByTestId('slide-icon-perps')).toBeTruthy();
   });
 
   it('has a "Get Started" or "Connect Wallet" button', () => {

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -103,7 +103,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
         keyExtractor={(_, i) => String(i)}
         renderItem={({ item }) => (
           <View style={[styles.slide, { width: SCREEN_WIDTH }]}>
-            <View style={styles.slideIconWrap}>
+            <View style={styles.slideIconWrap} testID={`slide-icon-${item.icon}`}>
               <OnboardingIcon type={item.icon} size={72} />
             </View>
             <Text style={styles.slideTitle}>{item.title}</Text>


### PR DESCRIPTION
## Summary
Fixes CI failure introduced by PERC-427 (PR #29). Closes #30.

## Problem
`OnboardingScreen.test.tsx` line 58 asserted `getByText('⚡')`, but PERC-427 replaced the emoji icon with an `<OnboardingIcon />` SVG component — removing all emoji text from the slide. This caused 1/188 tests to fail on `main`.

## Fix
- Added `testID={`slide-icon-${item.icon}`}` to the `slideIconWrap` View in `OnboardingScreen.tsx`
- Updated the test assertion to `getByTestId('slide-icon-perps')`

## Test Results
```
PASS __tests__/screens/OnboardingScreen.test.tsx
  OnboardingScreen
    ✓ renders first slide title (1992 ms)
    ✓ renders slide subtitle (10 ms)
    ✓ renders slide icons (11 ms)
    ✓ has a "Get Started" or "Connect Wallet" button (82 ms)
Tests: 4 passed, 4 total
```

## How to Test
`npx jest __tests__/screens/OnboardingScreen.test.tsx`