### PR TITLE
fix(security): guard _setReporterForTest behind NODE_ENV !== production (closes #51)

### DIFF
--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -81,7 +81,14 @@ export function captureMessage(
   }
 }
 
-/** Exposed for testing — allows tests to inject a mock Sentry instance. */
+/**
+ * Exposed for testing — allows tests to inject a mock Sentry instance.
+ * No-op in production builds so test infrastructure never ships as an
+ * active code path.
+ *
+ * @internal — import only in test files
+ */
 export function _setReporterForTest(mock: SentryLike | null): void {
+  if (process.env['NODE_ENV'] === 'production') return;
   _sentry = mock;
 }


### PR DESCRIPTION
## Problem
`_setReporterForTest` is exported from production `errorReporting.ts`. This function is test infrastructure and should never be an active code path in production builds.

**Security review finding:** LOW — PR #49/PERC-527 security audit (dcccrypto@, 2026-03-09)

## Fix

Add a single-line runtime guard:
```ts
if (process.env['NODE_ENV'] === 'production') return;
```

This makes the function a no-op in production while keeping it fully functional in test environments (jest sets `NODE_ENV = 'test'`).

## Testing
- 238/238 tests pass (including all 10 errorReporting unit tests)
- No test file changes required

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dashboard, Earn, Leaderboard, Stake screens and an Earn tab; Trade screen now shows Recent Trades.
  * New hooks: useTrades, useOpenInterest, useInsurance, useFunding; market logos and explorer URL builders; expanded API endpoints for leaderboard, trader, insurance, platform stats, and stake pools.
  * Wallet balance display and manual refresh supported across app (useMWA refreshBalance).

* **Bug Fixes**
  * Prevent test error-reporting configuration from being applied in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->