### PR TITLE
fix(PERC-562): update slab binary offsets post-PR#77

### DIFF
--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -54,8 +54,10 @@ const ACCT_POSITION_SIZE_OFF = 80;
 const ACCT_ENTRY_PRICE_OFF = 96;
 const ACCT_OWNER_OFF = 184;
 
-// Slab header + config start offsets (matches slab.ts ENGINE_OFF = 392)
-const ACCOUNTS_SECTION_OFF = 392 + 328; // header(72) + config(320) + engine(328)
+// Slab layout offsets (must match percolator-prog compiled constants)
+// HEADER_LEN=104, CONFIG_LEN=512, ENGINE_OFF=624, ACCOUNTS_OFFSET=9424
+// ACCOUNTS_SECTION_OFF = ENGINE_OFF + offset_of!(RiskEngine, accounts)
+const ACCOUNTS_SECTION_OFF = 624 + 9424; // 10048
 
 function parseAccounts(
   data: Uint8Array,

--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -107,11 +107,12 @@ const ACCT_MATCHER_CONTEXT_OFF = 152;
 const ACCT_OWNER_OFF = 184;
 const ACCT_KIND_OFF = 24; // 0=User, 1=LP
 
-// Engine section starts at 392 (header=72 + config=320)
-const ENGINE_OFF = 392;
+// Slab layout offsets (must match percolator-prog compiled constants)
+// HEADER_LEN=104, CONFIG_LEN=512, ENGINE_OFF=624, ACCOUNTS_OFFSET=9424
+const ENGINE_OFF = 624;
 
-// Accounts section starts at ENGINE_OFF + 328 (engine size)
-const ACCOUNTS_SECTION_OFF = ENGINE_OFF + 328;
+// ACCOUNTS_SECTION_OFF = ENGINE_OFF + offset_of!(RiskEngine, accounts)
+const ACCOUNTS_SECTION_OFF = ENGINE_OFF + 9424; // 10048
 
 interface SlabConfig {
   programId: PublicKey;


### PR DESCRIPTION
## Problem
Positions and trades broken — mobile app reads slab data from wrong byte offsets after PR#77 grew the RiskEngine struct.

## Root Cause
Hardcoded ACCOUNTS_SECTION_OFF=720 (header=72 + config=320 + engine=328) is stale.
Actual compiled values: HEADER=104, CONFIG=512, ENGINE_OFF=624, ACCOUNTS_OFFSET=9424 → **10048**.

## Changes
- usePositions.ts: ACCOUNTS_SECTION_OFF 720→10048
- useTrade.ts: ENGINE_OFF 392→624, ACCOUNTS_SECTION_OFF 720→10048

## Verified
Sizes confirmed via cargo example against percolator-prog compiled constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated account data parsing to ensure accurate retrieval with corrected offset alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->