### PR TITLE
fix(PERC-562): correct slab binary layout — positions and trade hooks broken

### DIFF
--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -13,14 +13,20 @@ import { useState, useEffect, useCallback } from 'react';
 import { PublicKey } from '@solana/web3.js';
 import { connection } from '../lib/solana';
 import { api } from '../lib/api';
+import {
+  detectLayout,
+  ACCT_ACCOUNT_ID_OFF,
+  ACCT_CAPITAL_OFF,
+  ACCT_KIND_OFF,
+  ACCT_PNL_OFF,
+  ACCT_POSITION_SIZE_OFF,
+  ACCT_ENTRY_PRICE_OFF,
+  ACCT_OWNER_OFF,
+} from '../lib/slabLayout';
 
 // ---------------------------------------------------------------------------
 // Binary parsing helpers (mirrors packages/core/src/solana/slab.ts)
 // ---------------------------------------------------------------------------
-
-function readU8(buf: Uint8Array, off: number): number {
-  return buf[off];
-}
 
 function readU64LE(buf: Uint8Array, off: number): bigint {
   const dv = new DataView(buf.buffer, buf.byteOffset + off, 8);
@@ -44,31 +50,22 @@ function readPubkey(buf: Uint8Array, off: number): string {
   return new PublicKey(bytes).toBase58();
 }
 
-// Account layout offsets (matches Rust struct)
-const ACCT_SIZE = 256; // each account slot is 256 bytes (incl. padding)
-const ACCT_ACCOUNT_ID_OFF = 0;
-const ACCT_CAPITAL_OFF = 8;
-const ACCT_KIND_OFF = 24;
-const ACCT_PNL_OFF = 32;
-const ACCT_POSITION_SIZE_OFF = 80;
-const ACCT_ENTRY_PRICE_OFF = 96;
-const ACCT_OWNER_OFF = 184;
-
-// Slab header + config start offsets (matches slab.ts ENGINE_OFF = 392)
-const ACCOUNTS_SECTION_OFF = 392 + 328; // header(72) + config(320) + engine(328)
-
 function parseAccounts(
   data: Uint8Array,
   ownerBase58: string,
 ): ParsedAccount[] {
-  const results: ParsedAccount[] = [];
-  let offset = ACCOUNTS_SECTION_OFF;
+  const layout = detectLayout(data.length);
+  if (!layout) return []; // unrecognised slab size — skip silently
 
-  while (offset + ACCT_SIZE <= data.length) {
+  const { accountsOff, accountSize } = layout;
+  const results: ParsedAccount[] = [];
+  let offset = accountsOff;
+
+  while (offset + accountSize <= data.length) {
     try {
-      const kindByte = readU8(data, offset + ACCT_KIND_OFF);
-      // kind 0 = User, kind 1 = LP; skip if invalid
-      if (kindByte > 1) { offset += ACCT_SIZE; continue; }
+      const kindByte = data[offset + ACCT_KIND_OFF];
+      // kind 0 = User, kind 1 = LP; skip if invalid (e.g. uninitialized slot)
+      if (kindByte > 1) { offset += accountSize; continue; }
 
       const owner = readPubkey(data, offset + ACCT_OWNER_OFF);
       if (owner === ownerBase58) {
@@ -86,7 +83,7 @@ function parseAccounts(
     } catch {
       // skip malformed slot
     }
-    offset += ACCT_SIZE;
+    offset += accountSize;
   }
   return results;
 }

--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -22,6 +22,17 @@ import {
 } from '@solana/web3.js';
 import { connection } from '../lib/solana';
 import { useMWA } from './useMWA';
+import {
+  detectLayout,
+  CFG_COLLATERAL_MINT_OFF,
+  CFG_VAULT_OFF,
+  CFG_FEED_ID_OFF,
+  CFG_ORACLE_AUTHORITY_OFF,
+  ACCT_KIND_OFF,
+  ACCT_OWNER_OFF,
+  ACCT_MATCHER_PROG_OFF,
+  ACCT_MATCHER_CTX_OFF,
+} from '../lib/slabLayout';
 
 // ---------------------------------------------------------------------------
 // Instruction tag constants (must match program/src/processor/mod.rs)
@@ -89,31 +100,8 @@ function readPubkey(buf: Uint8Array, off: number): PublicKey {
   return new PublicKey(buf.slice(off, off + 32));
 }
 
-const HEADER_LEN = 72;
-const CONFIG_OFF = HEADER_LEN; // config starts after header
-
-// Config layout offsets (relative to CONFIG_OFF)
-const CFG_PROGRAM_ID_OFF = 0;        // Pubkey (32)
-const CFG_ADMIN_OFF = 32;            // Pubkey (32)
-const CFG_ORACLE_AUTHORITY_OFF = 64; // Pubkey (32)
-const CFG_INDEX_FEED_ID_OFF = 96;    // [u8;32] feed id
-const CFG_VAULT_OFF = 128;           // Pubkey (32)
-const CFG_COLLATERAL_MINT_OFF = 160; // Pubkey (32)
-// CFG total = 320
-
-const ACCT_SIZE = 256;
-const ACCT_MATCHER_PROGRAM_OFF = 120;
-const ACCT_MATCHER_CONTEXT_OFF = 152;
-const ACCT_OWNER_OFF = 184;
-const ACCT_KIND_OFF = 24; // 0=User, 1=LP
-
-// Engine section starts at 392 (header=72 + config=320)
-const ENGINE_OFF = 392;
-
-// Accounts section starts at ENGINE_OFF + 328 (engine size)
-const ACCOUNTS_SECTION_OFF = ENGINE_OFF + 328;
-
 interface SlabConfig {
+  /** Solana program ID — taken from the slab account's owner field */
   programId: PublicKey;
   vault: PublicKey;
   collateralMint: PublicKey;
@@ -128,32 +116,48 @@ interface LPAccount {
   matcherContext: PublicKey;
 }
 
-function parseSlabConfig(data: Uint8Array): SlabConfig {
-  const base = CONFIG_OFF;
-  const programId = readPubkey(data, base + CFG_PROGRAM_ID_OFF);
-  const vault = readPubkey(data, base + CFG_VAULT_OFF);
-  const collateralMint = readPubkey(data, base + CFG_COLLATERAL_MINT_OFF);
-  const oracleAuthority = readPubkey(data, base + CFG_ORACLE_AUTHORITY_OFF);
-  const feedIdBytes = data.slice(base + CFG_INDEX_FEED_ID_OFF, base + CFG_INDEX_FEED_ID_OFF + 32);
-  const feedIdHex = Array.from(feedIdBytes)
+/**
+ * Parse the slab config section.
+ *
+ * Config layout (borsh-packed, no padding) — same for V0 and V1 shared fields:
+ *   +0   collateralMint    Pubkey
+ *   +32  vaultPubkey       Pubkey
+ *   +64  indexFeedId       [u8;32]
+ *   ... (funding / thresh params) ...
+ *   +288 oracleAuthority   Pubkey
+ *
+ * programId is NOT stored in the config; it is the Solana account owner.
+ */
+function parseSlabConfig(data: Uint8Array, programId: PublicKey): SlabConfig {
+  const layout = detectLayout(data.length);
+  const configOff = layout ? layout.headerLen : 72; // V0 headerLen = 72
+
+  const collateralMint = readPubkey(data, configOff + CFG_COLLATERAL_MINT_OFF);
+  const vault = readPubkey(data, configOff + CFG_VAULT_OFF);
+  const oracleAuthority = readPubkey(data, configOff + CFG_ORACLE_AUTHORITY_OFF);
+  const feedStart = configOff + CFG_FEED_ID_OFF;
+  const feedIdHex = Array.from(data.slice(feedStart, feedStart + 32))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
   return { programId, vault, collateralMint, oracleAuthority, feedIdHex };
 }
 
 function findFirstLP(data: Uint8Array): LPAccount | null {
-  let off = ACCOUNTS_SECTION_OFF;
+  const layout = detectLayout(data.length);
+  if (!layout) return null;
+
+  const { accountsOff, accountSize } = layout;
+  let off = accountsOff;
   let idx = 0;
-  while (off + ACCT_SIZE <= data.length) {
+  while (off + accountSize <= data.length) {
     const kind = data[off + ACCT_KIND_OFF];
     if (kind === 1) {
-      // LP account
       const owner = readPubkey(data, off + ACCT_OWNER_OFF);
-      const matcherProgram = readPubkey(data, off + ACCT_MATCHER_PROGRAM_OFF);
-      const matcherContext = readPubkey(data, off + ACCT_MATCHER_CONTEXT_OFF);
+      const matcherProgram = readPubkey(data, off + ACCT_MATCHER_PROG_OFF);
+      const matcherContext = readPubkey(data, off + ACCT_MATCHER_CTX_OFF);
       return { idx, owner, matcherProgram, matcherContext };
     }
-    off += ACCT_SIZE;
+    off += accountSize;
     idx++;
   }
   return null;
@@ -420,7 +424,9 @@ export function useTrade(): UseTradeResult {
         if (!slabInfo) throw new Error('Market not found on-chain');
 
         const data = new Uint8Array(slabInfo.data);
-        const config = parseSlabConfig(data);
+        // programId = the Solana program that owns this account
+        const programId = slabInfo.owner;
+        const config = parseSlabConfig(data, programId);
         const lp = findFirstLP(data);
         if (!lp) throw new Error('No LP account found — market has no liquidity');
 
@@ -440,19 +446,24 @@ export function useTrade(): UseTradeResult {
         let userIdx = params.userIdx;
         let needsInitUser = false;
 
+        // Detect slab layout for correct account scanning
+        const slabLayout = detectLayout(data.length);
+        if (!slabLayout) throw new Error('Unrecognised slab size — market may be corrupted');
+        const { accountsOff, accountSize, maxAccounts } = slabLayout;
+
         // Scan all accounts in the slab to find one owned by this wallet
         let existingIdx = -1;
         {
-          let scanOff = ACCOUNTS_SECTION_OFF;
+          let scanOff = accountsOff;
           let scanIdx = 0;
-          while (scanOff + ACCT_SIZE <= data.length) {
+          while (scanOff + accountSize <= data.length) {
             const acctOwner = readPubkey(data, scanOff + ACCT_OWNER_OFF);
             const acctKind = data[scanOff + ACCT_KIND_OFF];
             if (acctKind === 0 && acctOwner.equals(publicKey)) {
               existingIdx = scanIdx;
               break;
             }
-            scanOff += ACCT_SIZE;
+            scanOff += accountSize;
             scanIdx++;
           }
         }
@@ -462,14 +473,16 @@ export function useTrade(): UseTradeResult {
         } else {
           // User has no account — we need InitUser first
           needsInitUser = true;
-          // Find next empty slot (we'll use the total number of accounts as the new idx)
-          let totalAccounts = 0;
-          let scanOff = ACCOUNTS_SECTION_OFF;
-          while (scanOff + ACCT_SIZE <= data.length) {
-            totalAccounts++;
-            scanOff += ACCT_SIZE;
+          // Count used slots to find the next account index
+          let usedSlots = 0;
+          let scanOff = accountsOff;
+          while (scanOff + accountSize <= data.length && usedSlots < maxAccounts) {
+            const kind = data[scanOff + ACCT_KIND_OFF];
+            // A slot is used if kind is 0 (User) or 1 (LP)
+            if (kind <= 1) usedSlots++;
+            scanOff += accountSize;
           }
-          userIdx = totalAccounts;
+          userIdx = usedSlots;
         }
 
         // 6. Convert size to e6 (signed: positive = long, negative = short)

--- a/src/lib/slabLayout.ts
+++ b/src/lib/slabLayout.ts
@@ -1,0 +1,142 @@
+/**
+ * Percolator slab binary layout detection — mobile-safe port of
+ * packages/core/src/solana/slab.ts layout constants.
+ *
+ * Supports V0 (deployed devnet, HEADER=72 / CONFIG=408 / ACCT=240) and
+ * V1 (future upgrade, HEADER=104 / CONFIG=536 / ACCT=248).
+ *
+ * All offsets in this file must stay in sync with the authoritative source:
+ *   percolator-launch/packages/core/src/solana/slab.ts
+ */
+
+// ── V0 layout (deployed devnet program) ──────────────────────────────────────
+// InsuranceFund: {balance: U128, fee_revenue: U128} = 32 bytes
+// RiskParams: 56 bytes
+// No mark_price, no long_oi/short_oi, no emergency OI cap fields
+// Account: 240 bytes (no last_partial_liquidation_slot)
+const V0_HEADER_LEN = 72;
+const V0_ENGINE_OFF = 480;   // align_up(72 + 408, 8) = 480
+const V0_BITMAP_OFF = 320;   // engine-relative offset of bitmap
+const V0_ACCOUNT_SIZE = 240;
+
+// ── V1 layout (future program upgrade) ───────────────────────────────────────
+// InsuranceFund expanded, RiskParams 288 bytes, Account 248 bytes
+const V1_HEADER_LEN = 104;
+const V1_ENGINE_OFF = 640;   // align_up(104 + 536, 8) = 640
+const V1_BITMAP_OFF = 656;   // engine-relative offset of bitmap
+const V1_ACCOUNT_SIZE = 248;
+
+// Tiers supported by the program (maxAccounts per slab)
+const TIERS = [64, 256, 1024, 4096] as const;
+
+// Number of bytes between end of bitmap and start of next_free[] array:
+//   num_used_accounts: u16 (2) + _pad: [u8;6] (6) + next_account_id: u64 (8) + free_head: u16 (2) = 18
+const POST_BITMAP_BYTES = 18;
+
+function computeSlabSize(
+  engineOff: number,
+  bitmapOff: number,
+  accountSize: number,
+  maxAccounts: number,
+): number {
+  const bitmapWords = Math.ceil(maxAccounts / 64);
+  const bitmapBytes = bitmapWords * 8;
+  const nextFreeBytes = maxAccounts * 2;
+  const preAccountsLen = bitmapOff + bitmapBytes + POST_BITMAP_BYTES + nextFreeBytes;
+  const accountsOffRel = Math.ceil(preAccountsLen / 8) * 8;
+  return engineOff + accountsOffRel + maxAccounts * accountSize;
+}
+
+function computeAccountsOff(
+  engineOff: number,
+  bitmapOff: number,
+  maxAccounts: number,
+): number {
+  const bitmapWords = Math.ceil(maxAccounts / 64);
+  const bitmapBytes = bitmapWords * 8;
+  const nextFreeBytes = maxAccounts * 2;
+  const preAccountsLen = bitmapOff + bitmapBytes + POST_BITMAP_BYTES + nextFreeBytes;
+  return engineOff + Math.ceil(preAccountsLen / 8) * 8;
+}
+
+// Pre-compute (size → maxAccounts) maps for fast lookup
+const V0_SIZES = new Map<number, number>();
+const V1_SIZES = new Map<number, number>();
+for (const n of TIERS) {
+  V0_SIZES.set(computeSlabSize(V0_ENGINE_OFF, V0_BITMAP_OFF, V0_ACCOUNT_SIZE, n), n);
+  V1_SIZES.set(computeSlabSize(V1_ENGINE_OFF, V1_BITMAP_OFF, V1_ACCOUNT_SIZE, n), n);
+}
+
+export interface SlabLayoutInfo {
+  version: 0 | 1;
+  headerLen: number;
+  engineOff: number;
+  accountSize: number;
+  maxAccounts: number;
+  /** Absolute byte offset in the slab where the accounts array starts. */
+  accountsOff: number;
+}
+
+/**
+ * Detect slab layout version and tier from the raw data length.
+ * Returns null for unrecognised sizes.
+ */
+export function detectLayout(dataLen: number): SlabLayoutInfo | null {
+  const v0n = V0_SIZES.get(dataLen);
+  if (v0n !== undefined) {
+    return {
+      version: 0,
+      headerLen: V0_HEADER_LEN,
+      engineOff: V0_ENGINE_OFF,
+      accountSize: V0_ACCOUNT_SIZE,
+      maxAccounts: v0n,
+      accountsOff: computeAccountsOff(V0_ENGINE_OFF, V0_BITMAP_OFF, v0n),
+    };
+  }
+  const v1n = V1_SIZES.get(dataLen);
+  if (v1n !== undefined) {
+    return {
+      version: 1,
+      headerLen: V1_HEADER_LEN,
+      engineOff: V1_ENGINE_OFF,
+      accountSize: V1_ACCOUNT_SIZE,
+      maxAccounts: v1n,
+      accountsOff: computeAccountsOff(V1_ENGINE_OFF, V1_BITMAP_OFF, v1n),
+    };
+  }
+  return null;
+}
+
+// ── Config layout offsets (relative to configOff = headerLen) ────────────────
+// Matches parseConfig() in packages/core/src/solana/slab.ts (borsh-packed, no padding).
+//
+//   collateralMint        Pubkey  +0
+//   vaultPubkey           Pubkey  +32
+//   indexFeedId           Pubkey  +64
+//   maxStalenessSlots     u64     +96
+//   confFilterBps         u16     +104
+//   vaultAuthorityBump    u8      +106
+//   invert                u8      +107
+//   unitScale             u32     +108
+//   fundingHorizonSlots   u64     +112
+//   ...funding params...
+//   oracleAuthority       Pubkey  +288
+//   authorityPriceE6      u64     +320
+//   ...
+//
+export const CFG_COLLATERAL_MINT_OFF = 0;   // relative to configOff
+export const CFG_VAULT_OFF           = 32;  // relative to configOff
+export const CFG_FEED_ID_OFF         = 64;  // relative to configOff (indexFeedId)
+export const CFG_ORACLE_AUTHORITY_OFF = 288; // relative to configOff
+
+// ── Account field offsets (relative to start of each account slot) ───────────
+// First 240 bytes are identical in V0 and V1.
+export const ACCT_ACCOUNT_ID_OFF    = 0;   // u64
+export const ACCT_CAPITAL_OFF       = 8;   // U128 (16 bytes)
+export const ACCT_KIND_OFF          = 24;  // u8  (0=User, 1=LP)
+export const ACCT_PNL_OFF           = 32;  // I128 (16 bytes)
+export const ACCT_POSITION_SIZE_OFF = 80;  // I128 (16 bytes)
+export const ACCT_ENTRY_PRICE_OFF   = 96;  // u64
+export const ACCT_MATCHER_PROG_OFF  = 120; // Pubkey (32 bytes)
+export const ACCT_MATCHER_CTX_OFF   = 152; // Pubkey (32 bytes)
+export const ACCT_OWNER_OFF         = 184; // Pubkey (32 bytes)


### PR DESCRIPTION
## Problem
Mobile app shows zero positions and trade submissions fail ('No LP account found') for all users.

**Root causes:**
1. `ACCOUNTS_SECTION_OFF = 720` — hardcoded wrong for every deployed tier.  
   Correct value for V0/256-tier is **1368** (detected dynamically). The code was reading garbage bytes past the slab boundary.
2. `ACCT_SIZE = 256` — wrong for every deployed layout.  
   V0 = **240 bytes**, V1 (future) = **248 bytes**.
3. `parseSlabConfig` offsets completely wrong:
   - `programId@0` → actually `collateralMint` (programId is the Solana account *owner*)
   - `vault@128` → actually funding params  
   - `mint@160` → actually more funding params
   - `oracleAuthority@64` → actually `indexFeedId`

## Fixes
**New: `src/lib/slabLayout.ts`**
- Mobile-safe port of `core/slab.ts` layout detection
- Precomputes size→tier maps for V0 (HEADER=72, ENGINE=480, ACCT=240) and V1 (HEADER=104, ENGINE=640, ACCT=248)
- `detectLayout(dataLen)` returns `{ accountsOff, accountSize, maxAccounts, ... }`

**`usePositions.ts`**
- Replace hardcoded ACCOUNTS_SECTION_OFF + ACCT_SIZE with `detectLayout()`

**`useTrade.ts`**
- Fix config offsets: `collateralMint=+0, vault=+32, feedId=+64, oracleAuthority=+288`
- `programId` sourced from `slabInfo.owner` (the Solana account owner field)
- `findFirstLP` + user-account scan use `detectLayout()`

## Testing
`npx tsc --noEmit` passes (no errors in src/; pre-existing test file errors only).