### PR TITLE
fix: batch QA sweep — 6 bugs (GH #63-#68)

### DIFF
--- a/src/components/chart/MiniChart.tsx
+++ b/src/components/chart/MiniChart.tsx
@@ -84,11 +84,19 @@ export function MiniChart({
     };
   }, [data, width, height, color]);
 
-  if (loading || !chartData) {
+  if (loading) {
     return (
       <View style={[styles.container, { width, height: Math.max(height, MIN_CHART_HEIGHT) }]}>
         <ActivityIndicator color={colors.accent} size="small" />
         <Text style={styles.loadingText}>Loading chart…</Text>
+      </View>
+    );
+  }
+
+  if (!chartData) {
+    return (
+      <View style={[styles.container, { width, height: Math.max(height, MIN_CHART_HEIGHT) }]}>
+        <Text style={styles.loadingText}>No price data available</Text>
       </View>
     );
   }

--- a/src/hooks/useMWA.ts
+++ b/src/hooks/useMWA.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { Alert, Linking } from 'react-native';
 import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import { PublicKey } from '@solana/web3.js';
 import * as SecureStore from 'expo-secure-store';
@@ -56,13 +57,29 @@ export function useMWA() {
     } catch (err) {
       captureException(err, { source: 'useMWA.connect' });
 
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      const isNoWallet =
+        /no installed wallet|wallet.*not found|Found no.*wallet/i.test(rawMessage);
+
+      if (isNoWallet) {
+        Alert.alert(
+          'No Wallet Found',
+          'Please install a Solana wallet (Phantom or Solflare) to continue.',
+          [
+            { text: 'Install Phantom', onPress: () => Linking.openURL('https://phantom.app/download') },
+            { text: 'Cancel', style: 'cancel' },
+          ],
+        );
+      }
+
       const USER_CONTROLLED_MESSAGES = new Set([
         'Wallet returned no accounts. Please try again.',
       ]);
-      const rawMessage = err instanceof Error ? err.message : '';
-      const message = USER_CONTROLLED_MESSAGES.has(rawMessage)
-        ? rawMessage
-        : 'Failed to connect wallet. Please try again.';
+      const message = isNoWallet
+        ? 'No Solana wallet found. Please install Phantom or Solflare.'
+        : USER_CONTROLLED_MESSAGES.has(rawMessage)
+          ? rawMessage
+          : 'Failed to connect wallet. Please try again.';
 
       setConnecting(false);
       setError(message);

--- a/src/hooks/useMarkets.ts
+++ b/src/hooks/useMarkets.ts
@@ -74,8 +74,12 @@ export function useMarkets() {
       const mapped = data.map(mapMarket);
       setMarkets(mapped);
 
-      // Persist to cache for next startup (fire and forget)
-      SecureStore.setItemAsync(MARKETS_CACHE_KEY, JSON.stringify(mapped)).catch(() => {});
+      // Persist top markets to cache for next startup (fire and forget).
+      // SecureStore has a 2048-byte limit — only cache top 20 markets by volume.
+      const cacheSlice = [...mapped]
+        .sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0))
+        .slice(0, 20);
+      SecureStore.setItemAsync(MARKETS_CACHE_KEY, JSON.stringify(cacheSlice)).catch(() => {});
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load markets');
     } finally {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -218,7 +218,11 @@ export const api = {
 
   /** Get stake pools */
   async getStakePools(): Promise<StakePool[]> {
-    const data = await fetchJSON<{ pools: StakePool[] }>(`${WEB_API_BASE}/stake/pools`);
-    return data.pools;
+    const data = await fetchJSON<{ pools: any[] }>(`${WEB_API_BASE}/stake/pools`);
+    return data.pools.map((p) => ({
+      ...p,
+      // API returns cooldownSlots; convert to seconds (400ms/slot on Solana)
+      cooldownSeconds: p.cooldownSeconds ?? (p.cooldownSlots ?? 0) * 0.4,
+    }));
   },
 };

--- a/src/screens/LeaderboardScreen.tsx
+++ b/src/screens/LeaderboardScreen.tsx
@@ -183,7 +183,7 @@ export function LeaderboardScreen() {
       setLoading(true);
       setError(null);
       const data = await api.getLeaderboard(period);
-      setTraders(data.traders);
+      setTraders(data.leaderboard ?? data.traders ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
     } finally {

--- a/src/screens/MarketsScreen.tsx
+++ b/src/screens/MarketsScreen.tsx
@@ -321,7 +321,7 @@ export function MarketsScreen() {
         <TouchableOpacity
           style={styles.createMarketBtn}
           activeOpacity={0.7}
-          onPress={() => navigation.navigate('CreateMarket' as never)}
+          onPress={() => navigation.navigate('More' as never, { screen: 'CreateMarket' } as never)}
         >
           <Text style={styles.createMarketText}>+ Create Market</Text>
         </TouchableOpacity>


### PR DESCRIPTION
Fixes all bugs from QA mobile sweep (GH #60 already fixed in PR #61).

| Issue | Severity | Fix |
|-------|----------|-----|
| #63 | 🔴 CRITICAL | Leaderboard crash: `data.traders` → `data.leaderboard` |
| #64 | 🟡 HIGH | Stake NaN cooldown: convert `cooldownSlots` → seconds |
| #65 | 🔴 CRITICAL | Create Market nav: cross-stack navigation fix |
| #66 | 🔴 CRITICAL | Connect Wallet: Alert with install link when no wallet |
| #67 | 🟡 HIGH | SecureStore: cache top 20 markets only (2KB limit) |
| #68 | 🟡 HIGH | Trade screen: separate loading vs empty chart state |

Closes #63 #64 #65 #66 #67 #68