### PR TITLE
fix(earn): divide insurance balance/feeRevenue/OI by 1e6 — fixes GH #74

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -180,7 +180,15 @@ export const api = {
 
   /** Get insurance fund data */
   async getInsurance(slab: string): Promise<InsuranceData> {
-    return fetchJSON(`${API_BASE}/insurance/${slab}`);
+    const raw = await fetchJSON<InsuranceData>(`${API_BASE}/insurance/${slab}`);
+    // API returns e6 micro-units — convert to whole USD/token units
+    return {
+      ...raw,
+      currentBalance: raw.currentBalance / 1_000_000,
+      feeRevenue: raw.feeRevenue / 1_000_000,
+      totalOpenInterest: raw.totalOpenInterest / 1_000_000,
+      history: raw.history.map((h) => ({ ...h, balance: h.balance / 1_000_000 })),
+    };
   },
 
   /** Get platform aggregate stats */


### PR DESCRIPTION
## Problem (GH #74)

`/api/insurance/:slab` returns raw e6 micro-units:
```json
{ "currentBalance": 102016000000, "feeRevenue": 2016000000, "totalOpenInterest": 2000000000000 }
```

`EarnScreen.tsx` passed these directly to `formatUsd()`, producing:
- **BALANCE**: `$102,016.00M` (should be `$102,016`)
- **Fee Revenue**: `$2,016.00M` (should be `$2,016`)
- **Total TVL**: `$1.662868388872e+23M` (scientific notation overflow)

## Fix

Normalised at the API boundary in `getInsurance()` — divide `currentBalance`, `feeRevenue`, `totalOpenInterest`, and `history[].balance` by `1_000_000` so all callers see whole USD values automatically. No EarnScreen changes needed.

## Tests
```
Test Suites: 42 passed, 42 total
Tests:       312 passed, 312 total
```

Closes #74