### PR TITLE
fix(PERC-594): enforce 64-char name cap client-side + InputField maxLength prop

### DIFF
--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -11,6 +11,10 @@ interface InputFieldProps {
   suffix?: string;
   rightAction?: { label: string; onPress: () => void };
   keyboardType?: 'default' | 'numeric' | 'decimal-pad';
+  /** Maximum number of characters allowed. Enforced natively on iOS/Android. */
+  maxLength?: number;
+  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
+  autoCorrect?: boolean;
   style?: ViewStyle;
 }
 
@@ -22,6 +26,9 @@ export function InputField({
   suffix,
   rightAction,
   keyboardType = 'default',
+  maxLength,
+  autoCapitalize,
+  autoCorrect,
   style,
 }: InputFieldProps) {
   return (
@@ -35,6 +42,9 @@ export function InputField({
           placeholder={placeholder}
           placeholderTextColor={colors.textMuted}
           keyboardType={keyboardType}
+          maxLength={maxLength}
+          autoCapitalize={autoCapitalize}
+          autoCorrect={autoCorrect}
           selectionColor={colors.accent}
         />
         {suffix && <Text style={styles.suffix}>{suffix}</Text>}

--- a/src/screens/MarketCreationScreen.tsx
+++ b/src/screens/MarketCreationScreen.tsx
@@ -365,6 +365,7 @@ export function MarketCreationScreen() {
               placeholder="e.g. SOL-PERP"
               autoCapitalize="characters"
               autoCorrect={false}
+              maxLength={64}
             />
 
             <TouchableOpacity


### PR DESCRIPTION
## Summary
E2E devnet test (PERC-594) found that the Market Name field in MarketCreationScreen had no client-side character limit. The server rejects names >64 chars with a 400, but the form would let users type unlimited characters before the API call.

## Changes
- **`InputField` component**: Added `maxLength`, `autoCapitalize`, and `autoCorrect` props to interface + wired to `TextInput`
- **`MarketCreationScreen`**: Added `maxLength={64}` to the Market Name `InputField`

## Validation
- `autoCapitalize` and `autoCorrect` were already being passed in `MarketCreationScreen` but silently ignored (not in interface) — now properly forwarded
- Server-side guard: `/api/mobile/create-market` returns 400 for names >64 chars ✅
- Client-side guard: user cannot type past char 64 ✅
- 302/302 tests pass

## Test steps (from PERC-594 E2E)
- [x] oracle_mode validation: `POST /api/mobile/create-market` with invalid mode → 400 ✅
- [x] Name field cap: API returns 400 for >64-char names ✅  
- [x] Name field cap: mobile form now enforces maxLength={64} natively ✅
- [ ] Full mobile wallet connect + deploy flow — requires physical device (not automatable in CI)

## Closes
PERC-594 (partial — API validation passes, client cap added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market name input now limited to a maximum of 64 characters.
  * Input fields now support enhanced text customization options, including character length limits and auto-capitalization controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->