### PR TITLE
fix(GH-87): move ConnectWalletSheet to RootNavigator for global coverage

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,8 +1,11 @@
-import React, { useState, useCallback, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Text, ActivityIndicator, View, StyleSheet } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
+import BottomSheet from '@gorhom/bottom-sheet';
+import { ConnectWalletSheet } from '../components/wallet/ConnectWalletSheet';
+import { useMWA } from '../hooks/useMWA';
 import {
   MarketsTabIcon,
   TradeTabIcon,
@@ -177,6 +180,17 @@ const ONBOARDING_KEY = 'percolator_onboarded';
  */
 export function RootNavigator() {
   const [onboarded, setOnboarded] = useState<boolean | null>(null); // null = loading
+  const { showInstallSheet, dismissInstallSheet } = useMWA();
+  const installSheetRef = useRef<BottomSheet>(null);
+
+  // GH #87 — globally mount ConnectWalletSheet so it works from any screen
+  useEffect(() => {
+    if (showInstallSheet) {
+      installSheetRef.current?.expand();
+    } else {
+      installSheetRef.current?.close();
+    }
+  }, [showInstallSheet]);
 
   // Load persisted onboarding state on mount
   useEffect(() => {
@@ -203,9 +217,15 @@ export function RootNavigator() {
     );
   }
 
-  if (!onboarded) {
-    return <OnboardingScreen onComplete={handleOnboardingComplete} />;
-  }
-
-  return <MainTabs />;
+  return (
+    <>
+      {!onboarded ? (
+        <OnboardingScreen onComplete={handleOnboardingComplete} />
+      ) : (
+        <MainTabs />
+      )}
+      {/* GH #87 — global ConnectWalletSheet so all screens get the branded sheet */}
+      <ConnectWalletSheet ref={installSheetRef} onDismiss={dismissInstallSheet} />
+    </>
+  );
 }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -16,8 +16,8 @@ import { fonts } from '../theme/fonts';
 import { useMWA } from '../hooks/useMWA';
 import { useDemoStore } from '../store/demoStore';
 import { OnboardingSlide, OnboardingSlideData } from '../components/onboarding/OnboardingSlide';
-import { ConnectWalletSheet } from '../components/wallet/ConnectWalletSheet';
-import BottomSheet from '@gorhom/bottom-sheet';
+// GH #87 — ConnectWalletSheet moved to RootNavigator
+// BottomSheet import removed — GH #87 (ConnectWalletSheet now in RootNavigator)
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -69,20 +69,12 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
   const [showWallets, setShowWallets] = useState(false);
   const [connectStep, setConnectStep] = useState<ConnectStep>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
-  const { connect, error: mwaError, showInstallSheet, dismissInstallSheet } = useMWA();
+  const { connect, error: mwaError } = useMWA();
   const enterDemo = useDemoStore((s) => s.enterDemo);
-  const installSheetRef = useRef<BottomSheet>(null);
 
   const isTransitioning = useRef(false);
 
-  // GH #77 — open/close the branded install sheet based on useMWA state
-  React.useEffect(() => {
-    if (showInstallSheet) {
-      installSheetRef.current?.expand();
-    } else {
-      installSheetRef.current?.close();
-    }
-  }, [showInstallSheet]);
+  // GH #87 — ConnectWalletSheet logic moved to RootNavigator (global mount)
 
   // Translate raw MWA errors into user-friendly messages
   React.useEffect(() => {
@@ -236,8 +228,7 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
           </TouchableOpacity>
         </View>
 
-        {/* GH #77 — branded sheet replaces Alert.alert for no-wallet errors */}
-        <ConnectWalletSheet ref={installSheetRef} onDismiss={dismissInstallSheet} />
+        {/* GH #87 — ConnectWalletSheet moved to RootNavigator for global coverage */}
       </SafeAreaView>
     );
   }

--- a/src/screens/PortfolioScreen.tsx
+++ b/src/screens/PortfolioScreen.tsx
@@ -217,13 +217,10 @@ function EmptyOrders() {
 
 export function PortfolioScreen() {
   const [tab, setTab] = useState<'open' | 'history' | 'orders'>('open');
-  const { connected, publicKey, connect, error: mwaError } = useMWA();
+  const { connected, publicKey, connect } = useMWA();
   const navigation = useNavigation<any>();
 
-  // Show wallet connection errors to the user (#66)
-  useEffect(() => {
-    if (mwaError) Alert.alert('Wallet Error', mwaError);
-  }, [mwaError]);
+  // GH #87 — wallet error alerts removed; ConnectWalletSheet in RootNavigator handles this globally
   const { submitTrade, submitting } = useTrade();
   const setOpenPositionCount = usePositionStore((s) => s.setOpenPositionCount);
 


### PR DESCRIPTION
## Summary
Fixes #87 — ConnectWalletSheet was only mounted in OnboardingScreen, so PortfolioScreen (and any other screen) never showed the branded bottom sheet on wallet-not-found errors. Users saw a raw `Alert.alert('Wallet Error', ...)` instead.

## Changes
- **RootNavigator**: Mount `ConnectWalletSheet` globally with `useMWA` `showInstallSheet`/`dismissInstallSheet` wiring
- **PortfolioScreen**: Remove `Alert.alert('Wallet Error', mwaError)` useEffect — the global sheet handles this now
- **OnboardingScreen**: Remove local `ConnectWalletSheet` mount, `installSheetRef`, and related dead code

## How to Test
1. Skip onboarding → go to Portfolio tab
2. Tap Connect Wallet (with no MWA wallet installed)
3. **Expected**: Branded `ConnectWalletSheet` bottom sheet slides up with Phantom/Solflare CTAs
4. **Before**: Raw system Alert dialog appeared

## Note
TradeScreen:148 `Alert.alert` is a trade confirmation dialog, not a wallet error — intentionally left unchanged.

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet connection interface is now globally available across the app.

* **Refactor**
  * Centralized wallet error handling for improved consistency and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->