### PR TITLE
fix(portfolio): show ConnectWalletSheet instead of Alert.alert for no-wallet (#87)

### DIFF
--- a/src/screens/PortfolioScreen.tsx
+++ b/src/screens/PortfolioScreen.tsx
@@ -24,6 +24,7 @@ import { PositionDetailSheet } from '../components/trade/PositionDetailSheet';
 import { useMWA } from '../hooks/useMWA';
 import { usePositions, type Position } from '../hooks/usePositions';
 import { useTrade } from '../hooks/useTrade';
+import { ConnectWalletSheet } from '../components/wallet/ConnectWalletSheet';
 
 function PositionCard({
   position,
@@ -217,19 +218,22 @@ function EmptyOrders() {
 
 export function PortfolioScreen() {
   const [tab, setTab] = useState<'open' | 'history' | 'orders'>('open');
-  const { connected, publicKey, connect, error: mwaError } = useMWA();
+  const { connected, publicKey, connect, showInstallSheet, dismissInstallSheet } = useMWA();
   const navigation = useNavigation<any>();
-
-  // Show wallet connection errors to the user (#66)
-  useEffect(() => {
-    if (mwaError) Alert.alert('Wallet Error', mwaError);
-  }, [mwaError]);
   const { submitTrade, submitting } = useTrade();
   const setOpenPositionCount = usePositionStore((s) => s.setOpenPositionCount);
 
   // Bottom sheet refs
   const detailSheetRef = useRef<BottomSheet>(null);
   const closeSheetRef = useRef<BottomSheet>(null);
+  const installSheetRef = useRef<BottomSheet>(null);
+
+  // Open the branded ConnectWalletSheet when no wallet is installed (GH #87)
+  useEffect(() => {
+    if (showInstallSheet) {
+      installSheetRef.current?.expand();
+    }
+  }, [showInstallSheet]);
   const [selectedPosition, setSelectedPosition] = useState<Position | null>(null);
 
   const { positions, loading, error, refresh } = usePositions(
@@ -420,6 +424,9 @@ export function PortfolioScreen() {
         submitting={submitting}
         onClose={handlePartialClose}
       />
+
+      {/* Branded wallet install sheet — shown when no MWA wallet found (GH #87) */}
+      <ConnectWalletSheet ref={installSheetRef} onDismiss={dismissInstallSheet} />
     </SafeAreaView>
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
## Summary

Fixes #87 — branded ConnectWalletSheet was only mounted in OnboardingScreen. PortfolioScreen was still showing a raw `Alert.alert('Wallet Error', ...)` when no MWA wallet is installed.

## Root Cause

`useMWA.connect()` correctly sets `showInstallSheet = true` (PR #79 fix), but PortfolioScreen had its own `useEffect(() => { if (mwaError) Alert.alert(...) })` which fired first. And even if it didn't fire first, `ConnectWalletSheet` wasn't mounted in PortfolioScreen at all.

## Changes

- **`src/screens/PortfolioScreen.tsx`**:
  - Import `ConnectWalletSheet`
  - Add `installSheetRef` and consume `showInstallSheet`/`dismissInstallSheet` from `useMWA()`
  - Remove `Alert.alert('Wallet Error', mwaError)` useEffect
  - Mount `<ConnectWalletSheet ref={installSheetRef} onDismiss={dismissInstallSheet} />` in render tree

## How to Test

1. Run on an emulator with **no MWA wallet installed**
2. Open Portfolio tab → tap Connect Wallet
3. **Expected**: Branded bottom sheet slides up with Phantom/Solflare CTAs
4. **Previously**: System `Alert.alert` dialog appeared

## Tests

All useMWA tests pass (13/13). No new TS errors introduced.