### PR TITLE
fix(P0): force balance refetch after deposit/withdraw tx confirms

### DIFF
--- a/src/hooks/useCollateral.ts
+++ b/src/hooks/useCollateral.ts
@@ -16,6 +16,7 @@ import {
 } from '@solana/web3.js';
 import { connection } from '../lib/solana';
 import { useMWA } from './useMWA';
+import { usePositionStore } from '../store/positionStore';
 
 // ---------------------------------------------------------------------------
 // Instruction tag constants
@@ -249,6 +250,7 @@ export function useCollateral(): UseCollateralResult {
   const { publicKey, signAndSend } = useMWA();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const triggerRefresh = usePositionStore((s) => s.triggerRefresh);
 
   const deposit = useCallback(
     async (params: CollateralParams): Promise<CollateralResult | null> => {
@@ -303,7 +305,17 @@ export function useCollateral(): UseCollateralResult {
 
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const sig = results.signatures[0];
+
+        // P0 fix: confirm tx then force UI to re-read on-chain balances
+        try {
+          await connection.confirmTransaction(sig, 'confirmed');
+        } catch {
+          // Best-effort — still return the sig even if confirmation polling times out
+        }
+        triggerRefresh();
+
+        return { signature: sig };
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Deposit failed');
         return null;
@@ -311,7 +323,7 @@ export function useCollateral(): UseCollateralResult {
         setSubmitting(false);
       }
     },
-    [publicKey, signAndSend],
+    [publicKey, signAndSend, triggerRefresh],
   );
 
   const withdraw = useCallback(
@@ -366,7 +378,17 @@ export function useCollateral(): UseCollateralResult {
 
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const sig = results.signatures[0];
+
+        // P0 fix: confirm tx then force UI to re-read on-chain balances
+        try {
+          await connection.confirmTransaction(sig, 'confirmed');
+        } catch {
+          // Best-effort
+        }
+        triggerRefresh();
+
+        return { signature: sig };
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Withdraw failed');
         return null;
@@ -374,7 +396,7 @@ export function useCollateral(): UseCollateralResult {
         setSubmitting(false);
       }
     },
-    [publicKey, signAndSend],
+    [publicKey, signAndSend, triggerRefresh],
   );
 
   return { submitting, error, deposit, withdraw };

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -13,6 +13,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { PublicKey } from '@solana/web3.js';
 import { connection } from '../lib/solana';
 import { api } from '../lib/api';
+import { usePositionStore } from '../store/positionStore';
 
 // ---------------------------------------------------------------------------
 // Binary parsing helpers (mirrors packages/core/src/solana/slab.ts)
@@ -174,6 +175,7 @@ export function usePositions(walletPublicKey: string | null): UsePositionsResult
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
+  const refreshTick = usePositionStore((s) => s.refreshTick);
 
   const refresh = useCallback(() => setTick((t) => t + 1), []);
 
@@ -281,7 +283,7 @@ export function usePositions(walletPublicKey: string | null): UsePositionsResult
 
     load();
     return () => { cancelled = true; };
-  }, [walletPublicKey, tick]);
+  }, [walletPublicKey, tick, refreshTick]);
 
   return { positions, loading, error, refresh };
 }

--- a/src/store/positionStore.ts
+++ b/src/store/positionStore.ts
@@ -7,9 +7,14 @@ import { create } from 'zustand';
 interface PositionStore {
   openPositionCount: number;
   setOpenPositionCount: (count: number) => void;
+  /** Bump to force usePositions to re-fetch on-chain data (e.g. after deposit/withdraw). */
+  refreshTick: number;
+  triggerRefresh: () => void;
 }
 
 export const usePositionStore = create<PositionStore>((set) => ({
   openPositionCount: 0,
   setOpenPositionCount: (count) => set({ openPositionCount: count }),
+  refreshTick: 0,
+  triggerRefresh: () => set((s) => ({ refreshTick: s.refreshTick + 1 })),
 }));


### PR DESCRIPTION
## Summary
**P0 bug**: deposit collateral tx succeeds on-chain but balance never updates in the UI.

## Root Cause
1. `useCollateral` returned the tx signature immediately after `signAndSend` without waiting for on-chain confirmation
2. Nothing triggered `usePositions` to re-read on-chain slab data after the tx landed

The portfolio screen kept showing the pre-deposit balance because the slab account fetch was never re-triggered.

## Fix
- **`positionStore`**: Add `refreshTick` counter + `triggerRefresh()` — a global signal for `usePositions` to re-fetch
- **`useCollateral`**: After `signAndSend`, await `confirmTransaction(sig, 'confirmed')` then call `triggerRefresh()`. Both deposit and withdraw paths.
- **`usePositions`**: Subscribe to `refreshTick` in the fetch effect deps — bumping it triggers a full re-read of on-chain positions/balances

## How to Test
1. Open CollateralScreen → deposit any amount of USDC
2. After tx confirms, navigate to Portfolio
3. **Expected**: Balance reflects the deposit immediately
4. **Before**: Balance was stale until app restart or manual pull-to-refresh

## Files Changed
- `src/store/positionStore.ts` — +refreshTick/triggerRefresh
- `src/hooks/useCollateral.ts` — confirmTransaction + triggerRefresh after deposit/withdraw
- `src/hooks/usePositions.ts` — subscribe to refreshTick

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Position data now refreshes automatically after deposit and withdraw transactions.
  * Enhanced transaction confirmation handling for improved state accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->