### PR TITLE
fix(mobile): resolve 5 P0 bugs from live device testing

### DIFF
--- a/__tests__/screens/MarketCreationScreen.test.tsx
+++ b/__tests__/screens/MarketCreationScreen.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for src/screens/MarketCreationScreen.tsx (3-step wizard, GH #80)
+ * Tests for src/screens/MarketCreationScreen.tsx (5-step wizard: mint → tier → oracle → review → deploy)
  */
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
@@ -56,12 +56,11 @@ describe('MarketCreationScreen', () => {
     expect(toJSON()).not.toBeNull();
   });
 
-  it('shows step 1: mint address input and market name field', () => {
+  it('shows step 1: mint address input (market name is on oracle step 3)', () => {
     const { getAllByText } = render(<MarketCreationScreen />);
-    // "Create Market" title or "Mint Address" label should exist
+    // "Create Market" title or "Mint Address" label should exist in step 1
     expect(getAllByText(/Mint Address|Create Market/i).length).toBeGreaterThanOrEqual(1);
-    // Market Name field visible in step 1
-    expect(getAllByText(/Market Name|Name/i).length).toBeGreaterThanOrEqual(1);
+    // "Market Name" was moved to the Oracle step (step 3) — not shown in step 1
   });
 
   it('shows next/advance button in step 1', () => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+// Polyfill Web Crypto for React Native — MUST be the very first import.
+// Fixes: "crypto.getRandomValues() not supported" (uuid / @solana/web3.js).
+import 'react-native-get-random-values';
+
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/src/screens/FaucetScreen.tsx
+++ b/src/screens/FaucetScreen.tsx
@@ -136,7 +136,9 @@ export function FaucetScreen() {
     setMintLoading(true);
     try {
       // Backend faucet endpoint: POST /api/faucet/mint
-      const resp = await fetch('https://api.percolatorlaunch.com/api/faucet/mint', {
+      // Use the same env-var base as MarketCreationScreen so Railway URL is respected.
+      const API_BASE = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://percolatorlaunch.com/api';
+      const resp = await fetch(`${API_BASE}/faucet/mint`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ mint: caInput.trim(), wallet: publicKey?.toBase58() }),

--- a/src/screens/MarketCreationScreen.tsx
+++ b/src/screens/MarketCreationScreen.tsx
@@ -39,7 +39,9 @@ interface TokenMeta {
   initial_price_e6: string;
 }
 
-type WizardStep = 'mint' | 'tier' | 'review' | 'deploying' | 'done';
+// BUG-5 fix: 5-step wizard matching web flow.
+// Steps: mint → tier → oracle → review → (deploying) → done
+type WizardStep = 'mint' | 'tier' | 'oracle' | 'review' | 'deploying' | 'done';
 
 /* ── Tier config ─────────────────────────────────────────────────── */
 
@@ -51,24 +53,25 @@ interface TierOption {
   desc: string;
 }
 
+// BUG-3 fix: tier labels must match the web wizard (Small / Medium / Large).
 const TIER_OPTIONS: TierOption[] = [
   {
     key: 'small',
-    label: 'Micro',
+    label: 'Small',
     maxAccounts: 256,
     rentSol: '~0.44',
     desc: 'Great for testing. 256 max trader accounts.',
   },
   {
     key: 'medium',
-    label: 'Standard',
+    label: 'Medium',
     maxAccounts: 1024,
     rentSol: '~1.8',
     desc: 'Mid-scale markets. 1,024 max trader accounts.',
   },
   {
     key: 'large',
-    label: 'Pro',
+    label: 'Large',
     maxAccounts: 4096,
     rentSol: '~7',
     desc: 'Full production scale. 4,096 max trader accounts.',
@@ -180,8 +183,12 @@ export function MarketCreationScreen() {
           initial_price_e6: cfg.initialPriceE6 ?? '1000000',
         };
         setTokenMeta(meta);
-        if (!marketName || marketName === tokenMeta?.name) {
-          setMarketName(`${meta.symbol}-PERP`);
+        // BUG-4: guard against auto-populating with a raw mint address or junk.
+        // A valid ticker starts with a letter and is short (≤12 chars).
+        const symbolOk = /^[A-Za-z][A-Za-z0-9]{0,11}$/.test(meta.symbol ?? '');
+        const safeSymbol = symbolOk ? meta.symbol : 'UNKNOWN';
+        if (!marketName || marketName === tokenMeta?.name || marketName === tokenMeta?.symbol) {
+          setMarketName(`${safeSymbol}-PERP`);
         }
       } catch (e) {
         setMetaError(e instanceof Error ? e.message : 'Failed to fetch token info');
@@ -274,20 +281,24 @@ export function MarketCreationScreen() {
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
         <Text style={styles.title}>Create Market</Text>
+        {/* BUG-5: 5-step indicator matching web (mint → tier → oracle → review → deploy) */}
         <View style={styles.stepIndicator}>
-          {(['mint', 'tier', 'review'] as const).map((s, i) => (
-            <View
-              key={s}
-              style={[
-                styles.stepDot,
-                wizardStep === s && styles.stepDotActive,
-                (wizardStep === 'tier' && i < 1) ||
-                (wizardStep === 'review' && i < 2)
-                  ? styles.stepDotDone
-                  : null,
-              ]}
-            />
-          ))}
+          {(['mint', 'tier', 'oracle', 'review', 'deploying'] as const).map((s, i) => {
+            const STEPS = ['mint', 'tier', 'oracle', 'review', 'deploying'];
+            const currentIdx = STEPS.indexOf(wizardStep);
+            const isDone = i < currentIdx;
+            const isActive = s === wizardStep;
+            return (
+              <View
+                key={s}
+                style={[
+                  styles.stepDot,
+                  isActive && styles.stepDotActive,
+                  isDone && styles.stepDotDone,
+                ]}
+              />
+            );
+          })}
         </View>
       </View>
 
@@ -358,24 +369,15 @@ export function MarketCreationScreen() {
               </Panel>
             )}
 
-            <InputField
-              label="Market Name"
-              value={marketName}
-              onChangeText={setMarketName}
-              placeholder="e.g. SOL-PERP"
-              autoCapitalize="characters"
-              autoCorrect={false}
-              maxLength={64}
-            />
+            {/* BUG-4 fix: market name moved to oracle step so it can't show as mint addr */}
 
             <TouchableOpacity
               style={[
                 styles.primaryBtn,
-                (!mintInput.trim() || !marketName.trim() || metaLoading) &&
-                  styles.primaryBtnDisabled,
+                (!mintInput.trim() || metaLoading) && styles.primaryBtnDisabled,
               ]}
               onPress={() => setWizardStep('tier')}
-              disabled={!mintInput.trim() || !marketName.trim() || metaLoading}
+              disabled={!mintInput.trim() || metaLoading}
               activeOpacity={0.8}
             >
               <Text style={styles.primaryBtnText}>Next: Choose Tier →</Text>
@@ -444,7 +446,67 @@ export function MarketCreationScreen() {
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.primaryBtn, styles.primaryBtnFlex]}
+                onPress={() => setWizardStep('oracle')}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.primaryBtnText}>Next: Oracle →</Text>
+              </TouchableOpacity>
+            </View>
+          </>
+        )}
+
+        {/* ── Step 3: Oracle & Market Name ──────────────────── */}
+        {/* BUG-4 fix: market name lives here, isolated from the mint address field */}
+        {wizardStep === 'oracle' && (
+          <>
+            <Text style={styles.sectionTitle}>Oracle & Market Name</Text>
+            <Text style={styles.sectionDesc}>
+              Confirm the oracle source and set a display name for your market.
+            </Text>
+
+            <Panel style={styles.reviewPanel}>
+              <ReviewRow
+                label="Oracle mode"
+                value={tokenMeta?.pool ? '✓ Hyperp DEX pool' : 'Admin (devnet default)'}
+              />
+              {tokenMeta?.pool && (
+                <ReviewRow label="Pool" value={tokenMeta.pool.pairLabel} />
+              )}
+              {tokenMeta && (
+                <ReviewRow
+                  label="Initial price"
+                  value={`$${(Number(tokenMeta.initial_price_e6) / 1_000_000).toFixed(4)}`}
+                />
+              )}
+            </Panel>
+
+            {/* Market name input — separate from mint field to prevent confusion */}
+            <InputField
+              label="Market Name"
+              value={marketName}
+              onChangeText={setMarketName}
+              placeholder="e.g. SOL-PERP"
+              autoCapitalize="characters"
+              autoCorrect={false}
+              maxLength={64}
+            />
+
+            <View style={styles.navRow}>
+              <TouchableOpacity
+                style={styles.secondaryBtn}
+                onPress={() => setWizardStep('tier')}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.secondaryBtnText}>← Back</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.primaryBtn,
+                  styles.primaryBtnFlex,
+                  !marketName.trim() && styles.primaryBtnDisabled,
+                ]}
                 onPress={() => setWizardStep('review')}
+                disabled={!marketName.trim()}
                 activeOpacity={0.8}
               >
                 <Text style={styles.primaryBtnText}>Review →</Text>
@@ -453,7 +515,7 @@ export function MarketCreationScreen() {
           </>
         )}
 
-        {/* ── Step 3: Review & deploy ────────────────────────── */}
+        {/* ── Step 4: Review & deploy ────────────────────────── */}
         {wizardStep === 'review' && (
           <>
             <Text style={styles.sectionTitle}>Review & Deploy</Text>
@@ -510,7 +572,7 @@ export function MarketCreationScreen() {
 
             <TouchableOpacity
               style={[styles.secondaryBtn, { alignSelf: 'center' }]}
-              onPress={() => setWizardStep('tier')}
+              onPress={() => setWizardStep('oracle')}
               activeOpacity={0.8}
             >
               <Text style={styles.secondaryBtnText}>← Back</Text>


### PR DESCRIPTION
## Summary

Fixes all 5 P0 bugs reported by Khubair from live device testing.

---

### 🔴 BUG-1 — CRASH: crypto.getRandomValues() not supported
**File:** `index.js`
Added `import 'react-native-get-random-values'` as the **very first import** before anything else. This polyfills Web Crypto for React Native and fixes the deploy crash that was blocking all market creation.

### 🔴 BUG-2 — Faucet: Network request failed
**File:** `src/screens/FaucetScreen.tsx`
Changed the mint token endpoint from hardcoded `api.percolatorlaunch.com` to use `EXPO_PUBLIC_WEB_URL` env var (same pattern as MarketCreationScreen), so Railway URL is respected.

### 🔴 BUG-3 — Tier naming mismatch vs web
**File:** `src/screens/MarketCreationScreen.tsx`
Renamed labels: Micro→**Small**, Standard→**Medium**, Pro→**Large** to match web wizard exactly.

### 🔴 BUG-4 — Market name field shows mint address
**Files:** `src/screens/MarketCreationScreen.tsx`
Moved the Market Name input to step 3 (oracle step), isolated from the mint address field. Added regex guard on auto-populate — symbols not matching `[A-Za-z][A-Za-z0-9]{0,11}` fall back to `UNKNOWN-PERP` instead of populating with a raw mint address.

### 🔴 BUG-5 — Mobile wizard flow != web wizard flow
**Files:** `src/screens/MarketCreationScreen.tsx`, `__tests__/screens/MarketCreationScreen.test.tsx`
Expanded wizard from 3-step to **5-step**: mint → tier → oracle → review → deploy. Progress dots updated to 5. New oracle step (step 3) shows auto-detected pool/oracle mode + the market name input field.

---

## Testing
- 302/302 tests passing
- TypeScript: no new errors in changed files

## How to test
1. Build APK and install on device
2. Tap Deploy Market → should no longer crash with crypto error
3. Check tier labels show Small/Medium/Large
4. Enter mint address → proceed to step 3 → verify market name field is separate
5. Check faucet → mint tokens should use correct Railway URL