### PR TITLE
fix(ci): add react-native-get-random-values dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-get-random-values": "^2.0.0",
         "react-native-reanimated": "~3.19.5",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "^4.23.0",
@@ -9638,6 +9639,12 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -17745,6 +17752,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-get-random-values": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+      "integrity": "sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-base64-decode": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.81"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-reanimated": "~3.19.5",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.23.0",


### PR DESCRIPTION
## Problem
Android APK build CI has been broken since PRs #99 and #94 merged.

`index.js` imports `react-native-get-random-values` as a crypto polyfill (required first import), but the package was missing from `package.json`.

**Error:** `Unable to resolve module react-native-get-random-values from index.js`

## Fix
- Add `react-native-get-random-values@^2.0.0` to `dependencies`
- Update `package-lock.json`

## Testing
- `package.json` now includes the dependency
- `package-lock.json` resolves to v2.0.0 from npmjs
- Unblocks Android APK CI build

Fixes mobile CI (devops-reported)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->