### PR TITLE
fix(api): use percolatorlaunch.com/api as default base URL + bake Helius devnet key

### DIFF
--- a/src/hooks/usePriceStream.ts
+++ b/src/hooks/usePriceStream.ts
@@ -10,7 +10,7 @@ function buildWsUrl(): string {
   if (process.env.EXPO_PUBLIC_WS_URL) {
     return process.env.EXPO_PUBLIC_WS_URL;
   }
-  const apiKey = process.env.EXPO_PUBLIC_HELIUS_API_KEY;
+  const apiKey = process.env.EXPO_PUBLIC_HELIUS_API_KEY ?? 'ecfc91c7-b704-4c37-b10e-a277392830aa';
   if (!apiKey) {
     console.warn(
       '[usePriceStream] EXPO_PUBLIC_HELIUS_API_KEY is not set. ' +

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,8 +6,9 @@
  * - Next.js API: percolatorlaunch.com/api (leaderboard, trader stats, stake pools, market creation)
  */
 
-// Railway direct URL — api.percolatorlaunch.com DNS is misconfigured
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'https://percolator-api-production.up.railway.app';
+// All market/stats data served via percolatorlaunch.com/api (Next.js proxy to Supabase).
+// The old Railway direct URL requires auth headers not available on mobile.
+const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'https://percolatorlaunch.com/api';
 const WEB_API_BASE = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://percolatorlaunch.com/api';
 
 interface MarketData {

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -5,7 +5,7 @@ import { Connection, clusterApiUrl } from '@solana/web3.js';
  * hit mainnet. EXPO_PUBLIC_CLUSTER can override (e.g. "mainnet-beta" for prod).
  */
 const CLUSTER = (process.env.EXPO_PUBLIC_CLUSTER as 'devnet' | 'mainnet-beta') || 'devnet';
-const RPC_URL = process.env.EXPO_PUBLIC_RPC_URL || clusterApiUrl(CLUSTER);
+const RPC_URL = process.env.EXPO_PUBLIC_RPC_URL || 'https://devnet.helius-rpc.com/?api-key=ecfc91c7-b704-4c37-b10e-a277392830aa';
 
 export const connection = new Connection(RPC_URL, 'confirmed');
 export { CLUSTER };


### PR DESCRIPTION
## Problem
On fresh install the mobile app shows `⚠ API 403:` on every screen because the hardcoded fallback URL points to `percolator-api-production.up.railway.app` which returns 403 — it requires auth headers not available on mobile. Additionally, bare Gradle builds don't inject `EXPO_PUBLIC_*` vars from `.env.local`, so the fallback always fires.

## Changes
- `src/lib/api.ts`: `API_BASE` fallback → `https://percolatorlaunch.com/api`
- `src/hooks/usePriceStream.ts`: Helius devnet key as `??` fallback → price streaming works without env injection
- `src/lib/solana.ts`: Helius devnet RPC URL as fallback → faster, no rate-limiting vs public devnet

## Test
- No `⚠ API 403:` banner on Markets screen ✅
- Price streaming connects to Helius WS ✅
- All `/api/*` routes return 200 ✅

Fixes: API 403 on first launch