### PR TITLE
fix(mobile): align create market wizard step labels with web (#97)

### DIFF
--- a/src/hooks/useCreateMarket.ts
+++ b/src/hooks/useCreateMarket.ts
@@ -49,13 +49,13 @@ export interface CreateMarketState {
   slabAddress: string | null;
 }
 
+// Match web useCreateMarket STEP_LABELS exactly
 const STEP_LABELS = [
-  'Building transactions…',
-  'Creating slab & initializing market…',
-  'Oracle setup & crank…',
-  'Initializing LP…',
-  'Depositing collateral & insurance…',
-  'Creating insurance mint…',
+  'Creating slab & initializing market...',
+  'Oracle setup & pre-LP crank...',
+  'Initializing LP...',
+  'Depositing collateral, insurance & final crank...',
+  'Creating insurance LP mint...',
 ];
 
 export function useCreateMarket() {
@@ -156,13 +156,8 @@ export function useCreateMarket() {
         }
 
         // ── Steps 1–5: Sign and send each transaction via MWA ─────────────────
-        const stepLabels = [
-          'Signing: create slab & init market…',
-          'Signing: oracle setup & crank…',
-          'Signing: init LP…',
-          'Signing: deposit collateral & insurance…',
-          'Signing: create insurance mint…',
-        ];
+        // Match web STEP_LABELS for consistency
+        const stepLabels = STEP_LABELS;
 
         let firstSignature: string | null = null;
         for (let i = 0; i < txBytes.length; i++) {


### PR DESCRIPTION
Aligns mobile create market tx step labels with web's `STEP_LABELS` exactly:
1. Creating slab & initializing market...
2. Oracle setup & pre-LP crank...
3. Initializing LP...
4. Depositing collateral, insurance & final crank...
5. Creating insurance LP mint...

Removed the mobile-only 'Building transactions…' step that web doesn't have.
Wizard screens (Token → Slab Tier → Review) match web quick mode already.

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized step labels in the market creation flow to align with web behavior, ensuring consistent messaging across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->