### PR TITLE
fix(GH-109,GH-110): leaderboard null guard + wizard back navigation

### DIFF
--- a/src/screens/LeaderboardScreen.tsx
+++ b/src/screens/LeaderboardScreen.tsx
@@ -183,7 +183,9 @@ export function LeaderboardScreen() {
       setLoading(true);
       setError(null);
       const data = await api.getLeaderboard(period);
-      setTraders(data.leaderboard ?? data.traders ?? []);
+      const raw = data.leaderboard ?? data.traders ?? [];
+      // Guard against null/malformed entries from API (GH #109)
+      setTraders(Array.isArray(raw) ? raw.filter((t): t is LeaderboardEntry => t != null && typeof t.wallet === 'string') : []);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to load leaderboard';
       setError(msg.includes('429') ? 'Too many requests — pull to refresh' : msg);
@@ -196,7 +198,7 @@ export function LeaderboardScreen() {
     fetchLeaderboard();
   }, [fetchLeaderboard]);
 
-  const totalVolume = traders.reduce((sum, t) => sum + t.volume, 0);
+  const totalVolume = traders.reduce((sum, t) => sum + (t.volume ?? 0), 0);
 
   const currentUserEntry = walletAddress
     ? traders.find((t) => t.wallet === walletAddress)

--- a/src/screens/MarketCreationScreen.tsx
+++ b/src/screens/MarketCreationScreen.tsx
@@ -18,6 +18,7 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  BackHandler,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -194,6 +195,34 @@ export function MarketCreationScreen() {
   const [metaLoading, setMetaLoading] = useState(false);
   const [metaError, setMetaError] = useState<string | null>(null);
 
+  // GH #110: Header back arrow navigates wizard steps, not screen stack
+  const handleBack = useCallback(() => {
+    if (wizardStep === 'slab-tier') {
+      setWizardStep('token');
+    } else if (wizardStep === 'review') {
+      setWizardStep('slab-tier');
+    } else {
+      navigation.goBack();
+    }
+  }, [wizardStep, navigation]);
+
+  // GH #110: Intercept Android back button to navigate wizard steps instead of popping screen
+  useEffect(() => {
+    const handler = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (wizardStep === 'slab-tier') {
+        setWizardStep('token');
+        return true;
+      }
+      if (wizardStep === 'review') {
+        setWizardStep('slab-tier');
+        return true;
+      }
+      // deploying/done/token — let default navigation handle it
+      return false;
+    });
+    return () => handler.remove();
+  }, [wizardStep]);
+
   // Sync wizard to deploying/done states
   useEffect(() => {
     if (deployState.deploying) setWizardStep('deploying');
@@ -344,15 +373,12 @@ export function MarketCreationScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
-        <TouchableOpacity
-          onPress={() => navigation.goBack()}
-          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-          style={styles.closeBtn}
-        >
-          <Text style={styles.closeBtnText}>✕</Text>
-        </TouchableOpacity>
-        <Text style={styles.title}>Create Market</Text>
-        <View style={{ width: 32 }} />
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={handleBack} hitSlop={12} activeOpacity={0.7}>
+            <Text style={styles.headerBackArrow}>←</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>Create Market</Text>
+        </View>
       </View>
 
       {/* Step indicator (match web: "Step X of N — Label" + dots) */}
@@ -657,16 +683,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
-  closeBtn: {
-    width: 32,
-    height: 32,
+  headerRow: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
+    gap: 12,
   },
-  closeBtnText: {
-    fontSize: 18,
+  headerBackArrow: {
+    fontFamily: fonts.body,
+    fontSize: 20,
     color: colors.textSecondary,
-    fontWeight: '600',
   },
   title: {
     fontFamily: fonts.display,


### PR DESCRIPTION
## Fixes
### GH #109 — Leaderboard TypeError on 30d/All Time
- Add null/type guard: filter out null entries and entries missing `wallet` field before rendering
- Guard `volume` in reduce with `?? 0` fallback
- 24h/7d unaffected; 30d/All Time API responses may contain null or malformed entries

### GH #110 — Create Market ← BACK navigates to Settings
- Add `BackHandler` to intercept Android hardware back during wizard steps 2/3
- Replace ✕ close button with ← arrow that does wizard step-back (step 2→1, step 3→2) or `navigation.goBack()` on step 1
- Ensures consistent back behavior on both Android hardware button and visible header arrow

## Tests
All 313 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved leaderboard data reliability by handling malformed API responses and missing volume data.

* **UX Improvements**
  * Enhanced wizard navigation with back button in header for market creation screen.
  * Android back button now properly navigates through wizard steps instead of exiting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->