### PR TITLE
fix(PERC-603): slide 3 — drop '60s' multiplier suffix + correct cyan token to #22d3ee

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -37,8 +37,10 @@ const SLIDES: OnboardingSlideData[] = [
   },
   {
     index: 3,
-    title: 'Deploy in 60s',
-    subtitle: 'Create your own perpetual market in under a minute.',
+    // PERC-603: drop "s" suffix — "60s" too close to "60x" leverage notation.
+    // Subtitle spells out "seconds" to keep context unambiguous.
+    title: 'Deploy in 60',
+    subtitle: 'Create your own perpetual market in under 60 seconds.',
   },
 ];
 

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -38,12 +38,11 @@ export const colors = {
   warningSubtle: 'rgba(229, 161, 0, 0.08)',
   warningBorder: 'rgba(229, 161, 0, 0.2)',
 
-  // Highlights — Solana green (same as --cyan on web).
-  // NOTE: cyan and long are intentionally aliased to the same Solana green
-  // (#14F195). cyan = UI highlights, long = buy-side trading. Kept as
-  // separate semantic tokens so either can diverge independently later.
-  cyan: '#14F195',
-  cyanMuted: 'rgba(20, 241, 149, 0.08)',
+  // Highlights — true cyan (#22d3ee). PERC-603: diverged from Solana-green
+  // (#14F195). cyan = UI highlights / onboarding accents. long = buy-side
+  // trading. Kept as separate semantic tokens so each tracks its own role.
+  cyan: '#22d3ee',
+  cyanMuted: 'rgba(34, 211, 238, 0.08)',
 
   // Overlays
   bgOverlay: 'rgba(255, 255, 255, 0.06)',


### PR DESCRIPTION
## PERC-603 P2 Follow-ups

### Changes
- **Slide 3 title**: `'Deploy in 60s'` → `'Deploy in 60'` — drops the `s` suffix that reads visually like a leverage multiplier (`60x`) in a trading context
- **Slide 3 subtitle**: `'Create your own perpetual market in under a minute.'` → `'Create your own perpetual market in under 60 seconds.'` — spells out the unit explicitly so context is unambiguous
- **`tokens.ts` cyan**: `#14F195` (Solana-green) → `#22d3ee` (true cyan); `cyanMuted` alpha updated to match new hue

### Why
Designer review flagged two P2 issues after PERC-603 illustration merge:
1. `60s` in slide title looks too close to `60x` leverage notation — confusing in a trading app
2. `colors.cyan` was intentionally aliased to Solana-green but the note said it could diverge; designer confirmed target hue is `#22d3ee`

### No PNG regen needed
This is the pure code-level fix. Designer confirmed the PNG asset (`slide-3-deploy.png`) has the correct cyan in the illustration — the token was the mismatch.

### Test
- Onboarding slide 3 renders `Deploy in 60` (no `s`)
- Subtitle reads `Create your own perpetual market in under 60 seconds.`
- Any component using `colors.cyan` now renders `#22d3ee`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cyan color palette tokens for improved visual consistency throughout the interface.
  * Refined onboarding slide text to clearly specify deployment duration in seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->