### PR TITLE
ci: migrate to Blacksmith runners

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,7 @@ jobs:
 
   build-debug:
     name: Build Debug APK
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-22.04
     needs: test
     if: github.event_name == 'pull_request'
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   build-release:
     name: Build Release APK
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-22.04
     needs: test
     if: github.event_name == 'push'
     permissions:


### PR DESCRIPTION
Replaces all runs-on: ubuntu-* with runs-on: blacksmith-2vcpu-ubuntu-22.04 for faster CI. Blacksmith is a drop-in replacement for GitHub Actions runners. No workflow logic changes. Fast-track: trivial infra change, QA + security approve, devops merges.