### PR TITLE
ci: revert Blacksmith runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: blacksmith-2vcpu-ubuntu-22.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,7 @@ jobs:
 
   build-debug:
     name: Build Debug APK
-    runs-on: blacksmith-2vcpu-ubuntu-22.04
+    runs-on: ubuntu-22.04
     needs: test
     if: github.event_name == 'pull_request'
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   build-release:
     name: Build Release APK
-    runs-on: blacksmith-2vcpu-ubuntu-22.04
+    runs-on: ubuntu-22.04
     needs: test
     if: github.event_name == 'push'
     permissions:


### PR DESCRIPTION
Blacksmith runners (blacksmith-2vcpu-ubuntu-22.04) have no registered runners in this org — CI has been stuck/cancelled for 9+ hours. Reverts to standard GitHub-hosted ubuntu-22.04 runners to restore CI functionality immediately.

Root cause: PR #118 introduced Blacksmith runner labels but Blacksmith is not configured/registered for dcccrypto org.

Fixes: CI hanging on every push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->