### PR TITLE
fix: TradeButton design spec compliance (DESIGN-BRIEF-MOBILE-V2 §4.6)

### DIFF
--- a/__tests__/components/ui/TradeButton.test.tsx
+++ b/__tests__/components/ui/TradeButton.test.tsx
@@ -1,42 +1,48 @@
 /**
  * Tests for src/components/ui/TradeButton.tsx
+ *
+ * Design spec: DESIGN-BRIEF-MOBILE-V2.md §4.6
+ * - Long: #14F195 bg, bgVoid (#06060C) text
+ * - Short: #FF3B5C bg, white (#FFFFFF) text
+ * - Disabled: bgInset bg, textMuted text
+ * - Height: 56px (full CTA), 44px (sm)
+ * - Font: JetBrains Mono Bold 14px, radii.lg (12px)
  */
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { TradeButton } from '../../../src/components/ui/TradeButton';
+import { colors, radii } from '../../../src/theme/tokens';
 
 describe('TradeButton', () => {
   it('renders with the given label', () => {
     const { getByText } = render(
-      <TradeButton label="Long ▲" direction="long" />,
+      <TradeButton label="OPEN LONG ▲" direction="long" />,
     );
-    expect(getByText('Long ▲')).toBeTruthy();
+    expect(getByText('OPEN LONG ▲')).toBeTruthy();
   });
 
   it('renders short button', () => {
     const { getByText } = render(
-      <TradeButton label="Short ▼" direction="short" />,
+      <TradeButton label="OPEN SHORT ▼" direction="short" />,
     );
-    expect(getByText('Short ▼')).toBeTruthy();
+    expect(getByText('OPEN SHORT ▼')).toBeTruthy();
   });
 
   it('calls onPress when tapped', () => {
     const onPress = jest.fn();
     const { getByText } = render(
-      <TradeButton label="Long ▲" direction="long" onPress={onPress} />,
+      <TradeButton label="OPEN LONG ▲" direction="long" onPress={onPress} />,
     );
-
-    fireEvent.press(getByText('Long ▲'));
+    fireEvent.press(getByText('OPEN LONG ▲'));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   it('does not call onPress when disabled', () => {
     const onPress = jest.fn();
     const { getByText } = render(
-      <TradeButton label="Long ▲" direction="long" onPress={onPress} disabled />,
+      <TradeButton label="OPEN LONG ▲" direction="long" onPress={onPress} disabled />,
     );
-
-    fireEvent.press(getByText('Long ▲'));
+    fireEvent.press(getByText('OPEN LONG ▲'));
     expect(onPress).not.toHaveBeenCalled();
   });
 
@@ -52,5 +58,125 @@ describe('TradeButton', () => {
       <TradeButton label="Long" direction="long" fullWidth />,
     );
     expect(getByText('Long')).toBeTruthy();
+  });
+
+  it('applies long green background', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" />,
+    );
+    // Traverse up to touchable to check background style
+    const text = getByText('OPEN LONG ▲');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasBg = styles.some(
+      (s: any) => s && s.backgroundColor === colors.long,
+    );
+    expect(hasBg).toBe(true);
+  });
+
+  it('applies short red background', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN SHORT ▼" direction="short" />,
+    );
+    const text = getByText('OPEN SHORT ▼');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasBg = styles.some(
+      (s: any) => s && s.backgroundColor === colors.short,
+    );
+    expect(hasBg).toBe(true);
+  });
+
+  it('applies disabled bgInset background when disabled', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" disabled />,
+    );
+    const text = getByText('OPEN LONG ▲');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasDisabledBg = styles.some(
+      (s: any) => s && s.backgroundColor === colors.bgInset,
+    );
+    expect(hasDisabledBg).toBe(true);
+  });
+
+  it('uses dark (bgVoid) text on long button for contrast', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" />,
+    );
+    const text = getByText('OPEN LONG ▲');
+    const flatStyle = text.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasColor = styles.some(
+      (s: any) => s && s.color === colors.bgVoid,
+    );
+    expect(hasColor).toBe(true);
+  });
+
+  it('uses white text on short button for contrast', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN SHORT ▼" direction="short" />,
+    );
+    const text = getByText('OPEN SHORT ▼');
+    const flatStyle = text.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasColor = styles.some(
+      (s: any) => s && s.color === '#FFFFFF',
+    );
+    expect(hasColor).toBe(true);
+  });
+
+  it('uses textMuted color when disabled', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" disabled />,
+    );
+    const text = getByText('OPEN LONG ▲');
+    const flatStyle = text.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasColor = styles.some(
+      (s: any) => s && s.color === colors.textMuted,
+    );
+    expect(hasColor).toBe(true);
+  });
+
+  it('lg button has 56px height', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" />,
+    );
+    const text = getByText('OPEN LONG ▲');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasHeight = styles.some((s: any) => s && s.height === 56);
+    expect(hasHeight).toBe(true);
+  });
+
+  it('sm button has 44px height', () => {
+    const { getByText } = render(
+      <TradeButton label="Long" direction="long" size="sm" />,
+    );
+    const text = getByText('Long');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasHeight = styles.some((s: any) => s && s.height === 44);
+    expect(hasHeight).toBe(true);
+  });
+
+  it('uses radii.lg (12px) border radius on lg button', () => {
+    const { getByText } = render(
+      <TradeButton label="OPEN LONG ▲" direction="long" />,
+    );
+    const text = getByText('OPEN LONG ▲');
+    const btn = text.parent?.parent;
+    const flatStyle = btn?.props.style;
+    const styles = Array.isArray(flatStyle) ? flatStyle : [flatStyle];
+    const hasRadius = styles.some(
+      (s: any) => s && s.borderRadius === radii.lg,
+    );
+    expect(hasRadius).toBe(true);
   });
 });

--- a/src/components/ui/TradeButton.tsx
+++ b/src/components/ui/TradeButton.tsx
@@ -1,3 +1,14 @@
+/**
+ * TradeButton — spec-compliant CTA for opening long/short positions.
+ *
+ * Design: DESIGN-BRIEF-MOBILE-V2.md §4.6
+ *  - Long: #14F195 bg, bgVoid (#06060C) text — green on dark for contrast
+ *  - Short: #FF3B5C bg, white (#FFFFFF) text — red on white for contrast
+ *  - Height: 56px (full-width CTA), 44px (sm variant)
+ *  - Font: JetBrains Mono Bold 14px
+ *  - Border radius: radii.lg (12px)
+ *  - Disabled: bgInset bg, textMuted text (no opacity hack)
+ */
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
 import { colors, radii } from '../../theme/tokens';
@@ -23,13 +34,12 @@ export function TradeButton({
   style,
 }: TradeButtonProps) {
   const isLong = direction === 'long';
-  const bg = isLong ? colors.long : colors.short;
 
   return (
     <TouchableOpacity
       style={[
         styles.button,
-        { backgroundColor: bg },
+        isLong ? styles.longBg : styles.shortBg,
         size === 'sm' && styles.sm,
         fullWidth && styles.fullWidth,
         disabled && styles.disabled,
@@ -39,18 +49,37 @@ export function TradeButton({
       disabled={disabled}
       activeOpacity={0.8}
     >
-      <Text style={[styles.text, size === 'sm' && styles.textSm]}>{label}</Text>
+      <Text
+        style={[
+          styles.text,
+          // Long: dark text on green; Short: white text on red; Disabled: muted
+          disabled
+            ? styles.textDisabled
+            : isLong
+            ? styles.textLong
+            : styles.textShort,
+          size === 'sm' && styles.textSm,
+        ]}
+      >
+        {label}
+      </Text>
     </TouchableOpacity>
   );
 }
 
 const styles = StyleSheet.create({
   button: {
-    height: 52,
-    borderRadius: radii.xl,
+    height: 56,
+    borderRadius: radii.lg,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 20,
+  },
+  longBg: {
+    backgroundColor: colors.long,
+  },
+  shortBg: {
+    backgroundColor: colors.short,
   },
   sm: {
     height: 44,
@@ -61,13 +90,24 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   disabled: {
-    opacity: 0.4,
+    backgroundColor: colors.bgInset,
   },
   text: {
-    fontFamily: fonts.display,
-    fontSize: 16,
+    fontFamily: fonts.mono,
+    fontSize: 14,
     fontWeight: '700',
-    color: colors.text,
+    letterSpacing: 0.5,
+  },
+  textLong: {
+    // Dark text on green background — spec §4.6: bgVoid text on Long
+    color: colors.bgVoid,
+  },
+  textShort: {
+    // White text on red background
+    color: '#FFFFFF',
+  },
+  textDisabled: {
+    color: colors.textMuted,
   },
   textSm: {
     fontSize: 12,

--- a/src/screens/TradeScreen.tsx
+++ b/src/screens/TradeScreen.tsx
@@ -508,7 +508,9 @@ export function TradeScreen() {
           label={
             submitting
               ? 'Signing…'
-              : `OPEN ${direction.toUpperCase()} POSITION`
+              : direction === 'long'
+              ? 'OPEN LONG ▲'
+              : 'OPEN SHORT ▼'
           }
           direction={direction}
           fullWidth


### PR DESCRIPTION
## What changed

Aligns `TradeButton` and `TradeScreen` CTA with the designer's spec in `DESIGN-BRIEF-MOBILE-V2.md §4.6`.

### Changes

**`src/components/ui/TradeButton.tsx`**
- Height `52px → 56px` (spec: 56px)
- Border radius `radii.xl (16px) → radii.lg (12px)` (spec: radii.lg)
- Font: `fonts.display 16px → fonts.mono bold 14px` + letterSpacing 0.5
- Long button text: white → `colors.bgVoid (#06060C)` — dark on green for contrast
- Short button text: white — preserved (correct on red)
- Disabled: opacity hack → explicit bgInset bg + textMuted text

**`src/screens/TradeScreen.tsx`**
- CTA label: OPEN LONG POSITION → OPEN LONG ▲ / OPEN SHORT ▼ per spec

**`__tests__/components/ui/TradeButton.test.tsx`**
- 9 new design-spec assertion tests (bg colour, text colour, height, border-radius)

### Tests
```
Test Suites: 43 passed, 43 total
Tests:       335 passed, 335 total  (+9 new)
```

Closes design debt from DESIGN-BRIEF-MOBILE-V2 §4.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Trade button labels are now displayed as "OPEN LONG ▲" and "OPEN SHORT ▼" for improved visual clarity and user guidance.
  * Enhanced trade button visual styling with updated color schemes, sizing, typography refinements, border radius adjustments, and improved contrast for a more polished appearance across all interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->