### PR TITLE
feat: LeverageSlider a11y (issue #123) + §4.5 size input + CodeRabbit fixes

### DIFF
--- a/__tests__/components/ui/LeverageSlider.test.tsx
+++ b/__tests__/components/ui/LeverageSlider.test.tsx
@@ -94,12 +94,12 @@ describe('LeverageSlider', () => {
     expect(hitArea.props.accessibilityValue).toMatchObject({ min: 1, max: 20, now: 5 });
   });
 
-  it('fires onChange with a valid LeverageTick on pan release', () => {
+  it('fires onChange with the correct snapped LeverageTick on pan release', () => {
     const onChange = jest.fn();
     // Capture the config passed to PanResponder.create so we can invoke callbacks directly
     let capturedConfig: Record<string, Function> = {};
     const originalCreate = PanResponder.create.bind(PanResponder);
-    jest.spyOn(PanResponder, 'create').mockImplementationOnce((config) => {
+    const spy = jest.spyOn(PanResponder, 'create').mockImplementationOnce((config) => {
       capturedConfig = config as Record<string, Function>;
       return originalCreate(config);
     });
@@ -109,13 +109,13 @@ describe('LeverageSlider', () => {
     );
     const hitArea = UNSAFE_getByProps({ accessibilityRole: 'adjustable' });
 
-    // Simulate layout so liveWidth.current is set (does not trigger setState for test purposes)
+    // Simulate layout so liveWidth.current is set
     act(() => {
       hitArea.props.onLayout({ nativeEvent: { layout: { x: 0, y: 0, width: 300, height: 32 } } });
     });
 
     // Invoke PanResponder callbacks directly at locationX=240 (80% of 300px):
-    // fraction=0.8 → raw=round(0.8*19+1)=16 → snaps to 20
+    // fraction=0.8 → raw=round(0.8*19+1)=16 → snapToTick(16) → nearest tick = 20
     const mockEvt = { nativeEvent: { locationX: 240, locationY: 16 } };
     const mockGs = { dx: 10, dy: 0, moveX: 240, moveY: 16, vx: 0, vy: 0, x0: 50, y0: 16, numberActiveTouches: 1 };
     act(() => {
@@ -125,6 +125,29 @@ describe('LeverageSlider', () => {
 
     expect(onChange).toHaveBeenCalled();
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
-    expect(LEVERAGE_TICKS).toContain(lastCall);
+    // locationX=240/width=300 = 0.8 → raw≈16 → nearest tick is 20
+    expect(lastCall).toBe(20);
+
+    spy.mockRestore();
+  });
+
+  it('fires onChange via onAccessibilityAction increment/decrement', () => {
+    const onChange = jest.fn();
+    const { UNSAFE_getByProps } = render(
+      <LeverageSlider value={5} onChange={onChange} testID="leverage-slider" />,
+    );
+    const hitArea = UNSAFE_getByProps({ accessibilityRole: 'adjustable' });
+
+    // Increment from 5× → 10×
+    act(() => {
+      hitArea.props.onAccessibilityAction({ nativeEvent: { actionName: 'increment' } });
+    });
+    expect(onChange).toHaveBeenLastCalledWith(10);
+
+    // Decrement from 5× → 2× (value prop still 5 — component reads prop, not state)
+    act(() => {
+      hitArea.props.onAccessibilityAction({ nativeEvent: { actionName: 'decrement' } });
+    });
+    expect(onChange).toHaveBeenLastCalledWith(2);
   });
 });

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TextInput, Text, StyleSheet, ViewStyle } from 'react-native';
+import { View, TextInput, Text, Pressable, StyleSheet, ViewStyle } from 'react-native';
 import { colors, radii } from '../../theme/tokens';
 import { fonts } from '../../theme/fonts';
 
@@ -8,6 +8,8 @@ interface InputFieldProps {
   value: string;
   onChangeText: (text: string) => void;
   placeholder?: string;
+  /** Prefix displayed inside the input row — e.g. "$" for size inputs. */
+  prefix?: string;
   suffix?: string;
   rightAction?: { label: string; onPress: () => void };
   keyboardType?: 'default' | 'numeric' | 'decimal-pad';
@@ -23,6 +25,7 @@ export function InputField({
   value,
   onChangeText,
   placeholder,
+  prefix,
   suffix,
   rightAction,
   keyboardType = 'default',
@@ -35,6 +38,7 @@ export function InputField({
     <View style={style}>
       {label && <Text style={styles.label}>{label}</Text>}
       <View style={styles.container}>
+        {prefix && <Text style={styles.prefix}>{prefix}</Text>}
         <TextInput
           style={styles.input}
           value={value}
@@ -49,9 +53,15 @@ export function InputField({
         />
         {suffix && <Text style={styles.suffix}>{suffix}</Text>}
         {rightAction && (
-          <Text style={styles.rightAction} onPress={rightAction.onPress}>
-            {rightAction.label}
-          </Text>
+          <Pressable
+            onPress={rightAction.onPress}
+            style={({ pressed }) => [styles.maxBtn, pressed && { opacity: 0.75 }]}
+            accessibilityRole="button"
+            accessibilityLabel={rightAction.label}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text style={styles.maxBtnText}>{rightAction.label}</Text>
+          </Pressable>
         )}
       </View>
     </View>
@@ -73,6 +83,12 @@ const styles = StyleSheet.create({
     borderRadius: radii.lg,
     paddingHorizontal: 16,
   },
+  prefix: {
+    fontFamily: fonts.mono,
+    fontSize: 20,
+    color: colors.textMuted,
+    marginRight: 4,
+  },
   input: {
     flex: 1,
     fontFamily: fonts.mono,
@@ -85,11 +101,21 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     marginLeft: 8,
   },
-  rightAction: {
+  /** §4.5 MAX button — accentPillBg bg, accent text, radii.full, 36px height */
+  maxBtn: {
+    backgroundColor: colors.accentPillBg,
+    borderRadius: radii.full,
+    height: 36,
+    paddingHorizontal: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 10,
+  },
+  maxBtnText: {
     fontFamily: fonts.display,
     fontSize: 13,
-    fontWeight: '600',
-    color: colors.cyan,
-    marginLeft: 8,
+    fontWeight: '700',
+    color: colors.accent,
+    letterSpacing: 0.5,
   },
 });

--- a/src/components/ui/LeverageSlider.tsx
+++ b/src/components/ui/LeverageSlider.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   Animated,
   PanResponder,
+  Pressable,
   StyleSheet,
   LayoutChangeEvent,
   GestureResponderEvent,
@@ -151,7 +152,17 @@ export function LeverageSlider({ value, onChange, testID }: Props) {
         onLayout={onLayout}
         accessibilityRole="adjustable"
         accessibilityLabel="Leverage slider"
-        accessibilityValue={{ min: MIN, max: MAX, now: value }}
+        accessibilityValue={{ min: MIN, max: MAX, now: value, text: `${snapToTick(value)}×` }}
+        accessibilityActions={[{ name: 'increment' }, { name: 'decrement' }]}
+        onAccessibilityAction={(event) => {
+          const currentTick = snapToTick(value);
+          const idx = LEVERAGE_TICKS.indexOf(currentTick);
+          if (event.nativeEvent.actionName === 'increment') {
+            if (idx < LEVERAGE_TICKS.length - 1) onChange(LEVERAGE_TICKS[idx + 1]);
+          } else if (event.nativeEvent.actionName === 'decrement') {
+            if (idx > 0) onChange(LEVERAGE_TICKS[idx - 1]);
+          }
+        }}
         {...panResponder.panHandlers}
       >
         {/* Track */}
@@ -168,20 +179,26 @@ export function LeverageSlider({ value, onChange, testID }: Props) {
         )}
       </View>
 
-      {/* Tick labels */}
+      {/* Tick labels — pressable for screen-reader / tap-to-set */}
       <View style={styles.tickRow}>
         {LEVERAGE_TICKS.map((tick) => {
           const frac = valueToFraction(tick);
           const isActive = snapToTick(value) === tick;
           return (
-            <View
+            <Pressable
               key={tick}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel={`${tick}× leverage`}
+              accessibilityState={{ selected: isActive }}
+              onPress={() => onChange(tick)}
               style={[styles.tickLabelWrap, { left: `${frac * 100}%` as unknown as number }]}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             >
               <Text style={[styles.tickText, isActive && styles.tickTextActive]}>
                 {tick}×
               </Text>
-            </View>
+            </Pressable>
           );
         })}
       </View>

--- a/src/screens/TradeScreen.tsx
+++ b/src/screens/TradeScreen.tsx
@@ -36,12 +36,16 @@ type TradeRouteParams = {
   Trade: { direction?: 'long' | 'short' } | undefined;
 };
 
-/** Parse a legacy string leverage value like "5x" or "10x" to a number */
+const VALID_LEVERAGE_TICKS = [1, 2, 5, 10, 20] as const;
+
+/** Parse a legacy string leverage value like "5x" or "10x" to a valid LeverageTick */
 function parseLeverageSetting(raw: string | number | undefined): LeverageTick {
-  if (typeof raw === 'number') return raw as LeverageTick;
+  if (typeof raw === 'number') {
+    return (VALID_LEVERAGE_TICKS.includes(raw as LeverageTick) ? raw : 5) as LeverageTick;
+  }
   if (!raw) return 5;
   const n = parseInt(String(raw), 10);
-  return ([1, 2, 5, 10, 20].includes(n) ? n : 5) as LeverageTick;
+  return (VALID_LEVERAGE_TICKS.includes(n as LeverageTick) ? n : 5) as LeverageTick;
 }
 
 export function TradeScreen() {
@@ -79,16 +83,14 @@ export function TradeScreen() {
     if (navDirection) setDirection(navDirection);
   }, [navDirection]);
 
-  // Load settings on mount; once loaded, sync leverage from persisted default
+  // Load settings on mount; once loaded (or when defaultLeverage changes), sync leverage
   useEffect(() => {
     if (!settings.loaded) {
       settings.load();
     } else {
-      // Settings just became ready — update leverage to match persisted default
       setLeverage(parseLeverageSetting(settings.defaultLeverage));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settings.loaded]);
+  }, [settings.loaded, settings.defaultLeverage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Use live streamed price → API market price → last price history point → 0
   const price = livePrice
@@ -403,13 +405,14 @@ export function TradeScreen() {
           </TouchableOpacity>
         </View>
 
-        {/* Size Input */}
+        {/* Size Input — §4.5: $ prefix + styled MAX button */}
         <InputField
           label={`Size (${symbol.split('-')[0]})`}
           value={size}
           onChangeText={setSize}
           placeholder="0.00"
           keyboardType="decimal-pad"
+          prefix="$"
           rightAction={{
             label: 'MAX',
             onPress: () => {


### PR DESCRIPTION
## Summary

Closes #123

Three-part PR building on merged #122.

---

## 1. LeverageSlider — Accessibility (issue #123)

Screen readers (VoiceOver/TalkBack) can now fully interact with the leverage slider:

| Feature | Detail |
|---|---|
| `onAccessibilityAction` | Increment → next tick, Decrement → prev tick |
| `accessibilityValue.text` | Reads as `5×` instead of a raw number |
| Tick labels → `Pressable` | `accessibilityRole="button"`, `accessibilityLabel="5× leverage"`, `accessibilityState.selected` |
| Tick `hitSlop` | ±8px all sides — comfortable tap target for motor-impaired users |

---

## 2. InputField — §4.5 Size Input (DESIGN-BRIEF-MOBILE-V2)

```
[  $ ___________  ] [MAX]
```

- New `prefix` prop renders inline before TextInput (Mono 20px, textMuted)
- MAX button replaced with styled `Pressable` pill:
  - `accentPillBg` background, `accent` text, `radii.full`, 36px height
  - Pressed opacity feedback
- TradeScreen: passes `prefix="$"` to size InputField

---

## 3. CodeRabbit fixes (from PR #122 review)

| File | Fix |
|---|---|
| `TradeScreen.tsx` | `parseLeverageSetting`: validate numeric inputs against allow-list, not just string |
| `TradeScreen.tsx` | Settings hydration `useEffect`: add `settings.defaultLeverage` to deps array |
| `LeverageSlider.test.tsx` | Pan release: assert `toBe(20)` not just `toContain` |
| `LeverageSlider.test.tsx` | `spy.mockRestore()` after test to prevent leakage |
| `LeverageSlider.test.tsx` | Add `onAccessibilityAction` increment/decrement test |

---

## Tests

```
Test Suites: 44 passed, 44 total
Tests:       345 passed, 345 total  (+3 new)
```

## How to test

### Accessibility
1. Enable VoiceOver (iOS) or TalkBack (Android)
2. Navigate to TradeScreen → Leverage section
3. Slider announces as `Leverage slider`, current value e.g. `5×`
4. Swipe up/down to increment/decrement leverage
5. Tick labels are individually tappable by screen reader

### §4.5 Size Input
1. Open TradeScreen
2. Size input shows `$` prefix inline
3. MAX button is a purple pill (`accentPillBg` bg, `accent` text, rounded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input fields now support optional currency prefixes (e.g., "$")
  * Leverage slider accessibility actions for increment and decrement

* **Improvements**
  * Enhanced accessibility with interactive leverage tick labels and expanded touch targets
  * Stricter leverage value validation against valid tick values with sensible defaults
  * Better visual feedback for interactive controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->