### PR TITLE
fix(jest): restore full test suite — pnpm-compatible transformIgnorePatterns + RNTL peer dep

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,18 @@ module.exports = {
       },
     ],
   },
+  // pnpm stores packages under node_modules/.pnpm/<pkg@ver>/node_modules/<pkg>/
+  // so the pattern must match both flat (npm/yarn) and nested (pnpm) layouts.
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@solana-mobile/.*|@solana/.*|@supabase/.*|nativewind|zustand)',
+    'node_modules/(?!(.pnpm/[^/]+/node_modules/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@solana-mobile/.*|@solana/.*|@supabase/.*|nativewind|zustand))',
   ],
-  setupFiles: ['./jest.setup.js'],
+  // pnpm resolves react-test-renderer transitively to a patch version that
+  // doesn't match react exactly (e.g. 19.2.4 vs 19.1.0). RNTL's peer-dep
+  // check throws on any mismatch; skip it since the actual render path works.
+  testEnvironmentOptions: {
+    // Note: env vars for setupFiles must be set before module load.
+  },
+  setupFiles: ['<rootDir>/jest.env.js', './jest.setup.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/'],
   // Run serially to prevent Zustand store pollution between test suites

--- a/jest.env.js
+++ b/jest.env.js
@@ -1,0 +1,11 @@
+/**
+ * jest.env.js — loaded before jest.setup.js via setupFiles.
+ *
+ * pnpm resolves react-test-renderer transitively to a slightly different patch
+ * version than react itself (e.g. 19.2.4 vs 19.1.0). @testing-library/react-
+ * native's peer-dep guard throws on any exact-version mismatch; the official
+ * escape hatch is RNTL_SKIP_DEPS_CHECK=true.
+ *
+ * See: https://callstack.github.io/react-native-testing-library/docs/migration-guide
+ */
+process.env.RNTL_SKIP_DEPS_CHECK = 'true';


### PR DESCRIPTION
## Problem

All 45 test suites were failing with 0 tests collected after upgrading to `jest@30` + `react-native@0.81.5` under pnpm.

Two root causes:

### 1. `transformIgnorePatterns` pnpm incompatibility

pnpm stores packages under a virtual store path:
```
node_modules/.pnpm/<pkg@ver>/node_modules/<pkg>/
```

The old pattern only matched flat `node_modules/<pkg>` paths (npm/yarn layout). Under pnpm, `react-native/jest/setup.js` was never transformed by babel-jest, causing an immediate ESM syntax error:
```
SyntaxError: Cannot use import statement outside a module
```

**Fix:** Added `(.pnpm/[^/]+/node_modules/)?` prefix to the allow-list group so both flat and pnpm-nested paths are covered. Verified regex against real pnpm paths before applying.

### 2. `@testing-library/react-native` peer dep version mismatch

RNTL@13 enforces that `react` and `react-test-renderer` have identical versions. pnpm resolves `react-test-renderer` transitively to `19.2.4` while `react` is pinned at `19.1.0`. This patch mismatch triggers the guard and throws before any test runs.

**Fix:** Added `jest.env.js` to `setupFiles` (runs before `jest.setup.js`) that sets `RNTL_SKIP_DEPS_CHECK=true` — the official RNTL escape hatch for pnpm environments.

## Result

| Before | After |
|--------|-------|
| 45 suites FAIL, 0 tests | 45 suites PASS, **356 tests** ✅ |

## Files Changed

- `jest.config.js` — updated `transformIgnorePatterns`, added `jest.env.js` to `setupFiles`
- `jest.env.js` — new file, sets `RNTL_SKIP_DEPS_CHECK=true` with full comment explaining why

## How to Test

```bash
pnpm test
# Expected: Test Suites: 45 passed — Tests: 356 passed
```