### PR TITLE
feat(stake): real on-chain stake deposit/withdraw via MWA

### DIFF
--- a/__tests__/hooks/useStake.test.ts
+++ b/__tests__/hooks/useStake.test.ts
@@ -25,6 +25,9 @@ const mockGetLatestBlockhash = jest.fn(() =>
     lastValidBlockHeight: 100,
   }),
 );
+const mockConfirmTransaction = jest.fn(() =>
+  Promise.resolve({ value: { err: null } }),
+);
 jest.mock('../../src/lib/solana', () => ({
   connection: {
     getAccountInfo: (...args: any[]) =>
@@ -32,6 +35,9 @@ jest.mock('../../src/lib/solana', () => ({
     getLatestBlockhash: (...args: any[]) =>
       (global as any).__mockGetLatestBlockhash?.(...args) ??
       Promise.resolve({ blockhash: 'test', lastValidBlockHeight: 100 }),
+    confirmTransaction: (...args: any[]) =>
+      (global as any).__mockConfirmTransaction?.(...args) ??
+      Promise.resolve({ value: { err: null } }),
   },
 }));
 
@@ -96,11 +102,13 @@ describe('useStake', () => {
     jest.clearAllMocks();
     (global as any).__mockGetAccountInfo = mockGetAccountInfo;
     (global as any).__mockGetLatestBlockhash = mockGetLatestBlockhash;
+    (global as any).__mockConfirmTransaction = mockConfirmTransaction;
     mockGetAccountInfo.mockResolvedValue(null);
     mockGetLatestBlockhash.mockResolvedValue({
       blockhash: 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi',
       lastValidBlockHeight: 100,
     });
+    mockConfirmTransaction.mockResolvedValue({ value: { err: null } });
   });
 
   afterEach(() => {

--- a/src/hooks/useStake.ts
+++ b/src/hooks/useStake.ts
@@ -346,7 +346,7 @@ export function useStake(): UseStakeResult {
         const userLpAta = deriveATA(publicKey, lpMint);
 
         // Build tx
-        const { blockhash } = await connection.getLatestBlockhash('confirmed');
+        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
         const tx = new Transaction({ recentBlockhash: blockhash, feePayer: publicKey });
 
         tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 250_000 }));
@@ -378,7 +378,20 @@ export function useStake(): UseStakeResult {
 
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const signature = results.signatures[0];
+
+        // Wait for on-chain finality before reporting success
+        const confirmation = await connection.confirmTransaction(
+          { signature, blockhash, lastValidBlockHeight },
+          'confirmed',
+        );
+        if (confirmation.value.err) {
+          throw new Error(
+            `Transaction failed on-chain: ${JSON.stringify(confirmation.value.err)}`,
+          );
+        }
+
+        return { signature };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Stake deposit failed';
         setError(msg);
@@ -431,7 +444,7 @@ export function useStake(): UseStakeResult {
         }
 
         // Build tx
-        const { blockhash } = await connection.getLatestBlockhash('confirmed');
+        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
         const tx = new Transaction({ recentBlockhash: blockhash, feePayer: publicKey });
 
         tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
@@ -457,7 +470,20 @@ export function useStake(): UseStakeResult {
 
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const signature = results.signatures[0];
+
+        // Wait for on-chain finality before reporting success
+        const confirmation = await connection.confirmTransaction(
+          { signature, blockhash, lastValidBlockHeight },
+          'confirmed',
+        );
+        if (confirmation.value.err) {
+          throw new Error(
+            `Transaction failed on-chain: ${JSON.stringify(confirmation.value.err)}`,
+          );
+        }
+
+        return { signature };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Stake withdrawal failed';
         setError(msg);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -318,17 +318,24 @@ export const api = {
   /** Get stake pools */
   async getStakePools(): Promise<StakePool[]> {
     const data = await fetchJSON<{ pools: any[] }>(`${WEB_API_BASE}/stake/pools`);
-    return (data.pools ?? []).map((p) => ({
-      id: p.poolAddress ?? p.id ?? p.slabAddress,
-      name: p.name ?? `Pool ${(p.slabAddress ?? '').slice(0, 8)}`,
-      market: p.symbol ?? p.name ?? '',
-      slabAddress: p.slabAddress ?? '',
-      collateralMint: p.collateralMint ?? '',
-      tvl: p.tvl ?? 0,
-      apr: p.apr ?? null,
-      capUsed: p.capUsed ?? 0,
-      capMax: p.capTotal ?? p.capMax ?? 0,
-      cooldownSeconds: p.cooldownSeconds ?? Math.round((p.cooldownSlots ?? 0) * 0.4),
-    }));
+    return (data.pools ?? [])
+      .filter(
+        (p) =>
+          (p.poolAddress ?? p.id ?? p.slabAddress) &&
+          p.slabAddress &&
+          p.collateralMint,
+      )
+      .map((p) => ({
+        id: p.poolAddress ?? p.id ?? p.slabAddress,
+        name: p.name ?? `Pool ${(p.slabAddress ?? '').slice(0, 8)}`,
+        market: p.symbol ?? p.name ?? '',
+        slabAddress: p.slabAddress,
+        collateralMint: p.collateralMint,
+        tvl: p.tvl ?? 0,
+        apr: p.apr ?? null,
+        capUsed: p.capUsed ?? 0,
+        capMax: p.capTotal ?? p.capMax ?? 0,
+        cooldownSeconds: p.cooldownSeconds ?? Math.round((p.cooldownSlots ?? 0) * 0.4),
+      }));
   },
 };

--- a/src/screens/StakeScreen.tsx
+++ b/src/screens/StakeScreen.tsx
@@ -57,7 +57,7 @@ const PoolCard = memo(function PoolCard({ pool }: { pool: StakePool }) {
 
   const handleConfirm = useCallback(async () => {
     const parsed = parseFloat(amount);
-    if (!parsed || !isFinite(parsed) || parsed <= 0 || !pool.slabAddress || !pool.collateralMint) return;
+    if (!isFinite(parsed) || !parsed || parsed <= 0 || !pool.slabAddress || !pool.collateralMint) return;
 
     setTxSig(null);
     const amountBaseUnits = BigInt(Math.round(parsed * 10 ** DECIMALS));
@@ -226,7 +226,13 @@ const PoolCard = memo(function PoolCard({ pool }: { pool: StakePool }) {
               style={[styles.confirmBtn, mode === 'unstake' && styles.confirmBtnUnstake]}
               onPress={handleConfirm}
               activeOpacity={0.7}
-              disabled={submitting}
+              disabled={
+                submitting ||
+                !isFinite(parseFloat(amount)) ||
+                parseFloat(amount) <= 0 ||
+                !pool.slabAddress ||
+                !pool.collateralMint
+              }
             >
               {submitting ? (
                 <ActivityIndicator size="small" color="#000" />


### PR DESCRIPTION
## Summary

Implements real on-chain staking for the StakeScreen — replaces the 1500ms placeholder stub with proper Solana transactions via MWA.

## What changed

### `src/hooks/useStake.ts` (new)
Self-contained hook mirroring percolator-launch's `useStakeDeposit` + `useStakeWithdraw` but using MWA signAndSend for mobile. No SDK dependency — encodes directly against the Stake program.

- **STAKE_PROGRAM_ID**: `6aJb1F9CDCVWCNYFwj8aQsVb696YnW6J1FznteHq4Q6k`
- **PDAs derived**: `stake_pool` (`["stake_pool", slab]`), `vault_auth` (`["vault_auth", pool]`), `deposit_pda` (`["deposit", pool, user]`)
- **Pool account parsed**: lpMint at bytes 65-96, vault at 97-128
- **Deposit ix (tag 1)**: 11 accounts including sysvar\_clock + system\_program
- **Withdraw ix (tag 2)**: 10 accounts
- Amount validation (> 0, ≤ 10^15) runs before any network call
- Idempotent ATA create for collateral + LP ATAs on deposit
- LP ATA preflight on withdraw: descriptive error if user hasn't deposited yet

### `src/screens/StakeScreen.tsx` (updated)
- Import + wire `useStake` hook into PoolCard
- Per-card error display on tx failure
- Success toast with signature + solscan link on tx confirm
- Amount input → base units conversion (USDC 6 decimals)

### `src/lib/api.ts` (updated)
- `StakePool` type adds `slabAddress` + `collateralMint` fields
- `getStakePools()` normalises the REST response to the enriched type

### `__tests__/hooks/useStake.test.ts` (new)
17 tests covering:
- Wallet not connected → error
- Slab not found → error
- Pool not initialised / too small → error
- Pool owner mismatch → error
- Zero amount / exceeds MAX → error (validated before network calls)
- Deposit happy path: ATAs missing → creates both
- Deposit happy path: ATAs exist → no ATA creates
- MAX boundary (exactly at limit) → succeeds
- Withdraw: LP ATA missing → descriptive error
- Withdraw: collateral ATA missing → creates it
- Withdraw happy path + MAX boundary

## Test results
392/392 passing (was 375 before this PR)

## How to test
1. Connect MWA wallet with USDC balance
2. Navigate to Stake tab → expand a pool → enter amount → Confirm Stake
3. MWA approval prompt appears → approve → success toast with tx signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-chain stake deposit and withdrawal for mobile wallets with real transaction flow
  * Transaction signature tracking with tappable Solscan links and truncated display
* **Quality**
  * Improved input validation, clearer error handling, and automatic ATA creation when required
  * Confirm button disabled/loading tied to actual submission state
* **Tests**
  * Comprehensive Jest tests covering deposit/withdraw success and failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->