### PR TITLE
fix(mobile): HIGH-1/HIGH-2 — zero/NaN guards in useTrade + useCollateral

### DIFF
--- a/src/hooks/useCollateral.ts
+++ b/src/hooks/useCollateral.ts
@@ -268,6 +268,11 @@ export function useCollateral(): UseCollateralResult {
       setError(null);
 
       try {
+        // HIGH-2: Guard against zero/NaN amount — reject before building transaction
+        if (!Number.isFinite(params.amount) || params.amount <= 0) {
+          throw new Error('Amount must be a positive finite number');
+        }
+
         const slabPk = new PublicKey(params.slabAddress);
         const slabInfo = await connection.getAccountInfo(slabPk);
         if (!slabInfo) throw new Error('Market not found on-chain');
@@ -340,6 +345,11 @@ export function useCollateral(): UseCollateralResult {
       setError(null);
 
       try {
+        // HIGH-2: Guard against zero/NaN amount — reject before building transaction
+        if (!Number.isFinite(params.amount) || params.amount <= 0) {
+          throw new Error('Withdraw amount must be a positive finite number');
+        }
+
         const slabPk = new PublicKey(params.slabAddress);
         const slabInfo = await connection.getAccountInfo(slabPk);
         if (!slabInfo) throw new Error('Market not found on-chain');

--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -422,6 +422,11 @@ export function useTrade(): UseTradeResult {
       setError(null);
 
       try {
+        // HIGH-2: Guard against zero/NaN sizeUsd — reject before MWA signing
+        if (!Number.isFinite(params.sizeUsd) || params.sizeUsd === 0) {
+          throw new Error('Trade size must be a non-zero finite number');
+        }
+
         const slabPk = new PublicKey(params.slabAddress);
 
         // 1. Fetch slab account data


### PR DESCRIPTION
## Summary
Two HIGH findings from PM mobile audit — fixes for fund-safety issues.

## Changes
### HIGH-1: Float→BigInt precision loss (useCollateral/useTrade)
`Math.round` before `BigInt()` conversion was already in place in both hooks (`Math.round(params.amount * 10 ** decimals)` in useCollateral, `Math.round(Math.abs(params.sizeUsd) * 1_000_000)` in useTrade). No change needed — confirmed present.

### HIGH-2: Zero/NaN sizeUsd no-op MWA trade (useTrade + useCollateral)
Added `Number.isFinite` + non-zero guards **before** any transaction is built:
- `useTrade.submitTrade`: rejects `sizeUsd === 0` or `NaN/Infinity` with a clear error message, before fetching slab or calling MWA
- `useCollateral.deposit` + `useCollateral.withdraw`: rejects `amount <= 0` or `NaN/Infinity`

This prevents no-op transaction submissions reaching the wallet signer.

## Tests
- 432/432 passing (all 48 suites)

## Review Checklist
- [x] HIGH-1: Math.round present in both hooks (verified, no change needed)
- [x] HIGH-2: Guards added before MWA signing in useTrade + useCollateral
- [x] All tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject transactions with invalid or zero amounts before processing.
  * Added validation to reject trades with invalid or zero size before transaction construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->