### PR TITLE
fix(mobile): pass oracle_mode from tokenMeta to deploy (PERC-8370)

### DIFF
--- a/src/screens/MarketCreationScreen.tsx
+++ b/src/screens/MarketCreationScreen.tsx
@@ -291,7 +291,7 @@ export function MarketCreationScreen() {
       mint: mintInput.trim(),
       name: marketName || `${mintInput.trim().slice(0, 6)}-PERP`,
       tier: selectedTier,
-      oracle_mode: 'admin',
+      oracle_mode: tokenMeta?.oracle_mode ?? 'admin',
       initial_price_e6: tokenMeta?.initial_price_e6 ?? '1000000',
     });
   }, [connected, mintInput, marketName, selectedTier, tokenMeta, deploy]);


### PR DESCRIPTION
## Problem
`handleDeploy` hardcoded `oracle_mode: 'admin'` regardless of the resolved tokenMeta value from the server config. Markets with HyperP or Pyth oracles were deployed with the wrong oracle mode.

## Fix
Changed line 294 in `MarketCreationScreen.tsx`:
```diff
- oracle_mode: 'admin',
+ oracle_mode: tokenMeta?.oracle_mode ?? 'admin',
```

Falls back to `'admin'` only when tokenMeta is not yet resolved.

## Testing
- Create a market for a token with a known HyperP pool → oracle_mode should be `'hyperp'`
- Create a market for a token with no pool → oracle_mode should fall back to `'admin'`

Closes GH#1989 | PERC-8370