### PR TITLE
fix(hooks): add tx confirmation + signature validation to useInsuranceLP

### DIFF
--- a/__tests__/hooks/useInsuranceLP.test.ts
+++ b/__tests__/hooks/useInsuranceLP.test.ts
@@ -36,6 +36,13 @@ jest.mock('../../src/lib/solana', () => {
   };
 });
 
+// ── confirmTransaction mock ───────────────────────────────────────────────
+const mockConfirmTransactionSafe = jest.fn(() => Promise.resolve());
+jest.mock('../../src/lib/confirmTransaction', () => ({
+  confirmTransactionSafe: (...args: any[]) =>
+    (global as any).__mockConfirmTransactionSafe?.(...args) ?? Promise.resolve(),
+}));
+
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const PROGRAM_ID = new PublicKey('GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24');
@@ -116,6 +123,8 @@ describe('useInsuranceLP', () => {
     // Wire global shims so the jest.mock factory delegates to our jest.fn()
     (global as any).__mockGetAccountInfo = mockGetAccountInfo;
     (global as any).__mockGetLatestBlockhash = mockGetLatestBlockhash;
+    (global as any).__mockConfirmTransactionSafe = mockConfirmTransactionSafe;
+    mockConfirmTransactionSafe.mockResolvedValue(undefined);
     // Reset defaults
     mockGetAccountInfo.mockResolvedValue(null);
     mockGetLatestBlockhash.mockResolvedValue({
@@ -260,6 +269,63 @@ describe('useInsuranceLP', () => {
       expect(addSpy.mock.calls.length).toBe(5);
       addSpy.mockRestore();
     });
+
+    it('calls confirmTransactionSafe after signAndSend with correct args', async () => {
+      setupConnectedWallet();
+      const slabData = makeMockSlabData();
+      const existingAta = { data: Buffer.alloc(165), owner: TOKEN_PROGRAM_ID };
+
+      mockGetAccountInfo
+        .mockResolvedValueOnce({ data: Buffer.from(slabData), owner: PROGRAM_ID })
+        .mockResolvedValueOnce(existingAta)
+        .mockResolvedValueOnce(existingAta);
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      await act(async () => {
+        await result.current.depositInsuranceLP({
+          slabAddress: PROGRAM_ID.toBase58(),
+          amountBaseUnits: 1_000_000n,
+        });
+      });
+
+      expect(mockConfirmTransactionSafe).toHaveBeenCalledTimes(1);
+      expect(mockConfirmTransactionSafe).toHaveBeenCalledWith(
+        expect.anything(),            // connection
+        expect.anything(),            // signature
+        'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi', // blockhash
+        100,                          // lastValidBlockHeight
+      );
+    });
+
+    it('returns null and sets error when confirmTransactionSafe throws on-chain error', async () => {
+      setupConnectedWallet();
+      const slabData = makeMockSlabData();
+      const existingAta = { data: Buffer.alloc(165), owner: TOKEN_PROGRAM_ID };
+
+      mockGetAccountInfo
+        .mockResolvedValueOnce({ data: Buffer.from(slabData), owner: PROGRAM_ID })
+        .mockResolvedValueOnce(existingAta)
+        .mockResolvedValueOnce(existingAta);
+
+      mockConfirmTransactionSafe.mockRejectedValueOnce(
+        new Error('Transaction failed on-chain: {"InstructionError":[0,{"Custom":6001}]}'),
+      );
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      let returnVal: any;
+      await act(async () => {
+        returnVal = await result.current.depositInsuranceLP({
+          slabAddress: PROGRAM_ID.toBase58(),
+          amountBaseUnits: 1_000_000n,
+        });
+      });
+
+      expect(returnVal).toBeNull();
+      expect(result.current.error).toMatch(/Transaction failed on-chain/);
+      expect(result.current.submitting).toBe(false);
+    });
   });
 
   // ── withdrawInsuranceLP ────────────────────────────────────────────────
@@ -349,6 +415,63 @@ describe('useInsuranceLP', () => {
 
       expect(addSpy.mock.calls.length).toBe(3);
       addSpy.mockRestore();
+    });
+
+    it('calls confirmTransactionSafe after signAndSend with correct args', async () => {
+      setupConnectedWallet();
+      const slabData = makeMockSlabData();
+      const existingAta = { lamports: 1 };
+
+      mockGetAccountInfo
+        .mockResolvedValueOnce({ data: Buffer.from(slabData), owner: PROGRAM_ID })
+        .mockResolvedValueOnce(existingAta)
+        .mockResolvedValueOnce(existingAta);
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      await act(async () => {
+        await result.current.withdrawInsuranceLP({
+          slabAddress: PROGRAM_ID.toBase58(),
+          lpAmountBaseUnits: 2_000_000n,
+        });
+      });
+
+      expect(mockConfirmTransactionSafe).toHaveBeenCalledTimes(1);
+      expect(mockConfirmTransactionSafe).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi',
+        100,
+      );
+    });
+
+    it('returns null and sets error when confirmTransactionSafe throws on-chain error', async () => {
+      setupConnectedWallet();
+      const slabData = makeMockSlabData();
+      const existingAta = { lamports: 1 };
+
+      mockGetAccountInfo
+        .mockResolvedValueOnce({ data: Buffer.from(slabData), owner: PROGRAM_ID })
+        .mockResolvedValueOnce(existingAta)
+        .mockResolvedValueOnce(existingAta);
+
+      mockConfirmTransactionSafe.mockRejectedValueOnce(
+        new Error('Transaction failed on-chain: {"InstructionError":[0,{"Custom":6001}]}'),
+      );
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      let returnVal: any;
+      await act(async () => {
+        returnVal = await result.current.withdrawInsuranceLP({
+          slabAddress: PROGRAM_ID.toBase58(),
+          lpAmountBaseUnits: 2_000_000n,
+        });
+      });
+
+      expect(returnVal).toBeNull();
+      expect(result.current.error).toMatch(/Transaction failed on-chain/);
+      expect(result.current.submitting).toBe(false);
     });
   });
 

--- a/src/hooks/useInsuranceLP.ts
+++ b/src/hooks/useInsuranceLP.ts
@@ -24,6 +24,7 @@ import {
   ComputeBudgetProgram,
 } from '@solana/web3.js';
 import { connection } from '../lib/solana';
+import { confirmTransactionSafe } from '../lib/confirmTransaction';
 import { useMWA } from './useMWA';
 import {
   detectSlabLayout,
@@ -311,7 +312,7 @@ export function useInsuranceLP(): UseInsuranceLPResult {
         const userLpAta = deriveATA(publicKey, lpMint);
 
         // 3. Build tx — prepend ATA create-idempotent instructions for both ATAs
-        const { blockhash } = await connection.getLatestBlockhash('confirmed');
+        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
         const tx = new Transaction({ recentBlockhash: blockhash, feePayer: publicKey });
 
         tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
@@ -345,7 +346,14 @@ export function useInsuranceLP(): UseInsuranceLPResult {
         // 4. Sign + send via MWA
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const signature = results.signatures[0];
+        if (!signature) {
+          throw new Error('Deposit signAndSend returned no signature');
+        }
+
+        // 5. Confirm the transaction landed and did not fail on-chain
+        await confirmTransactionSafe(connection, signature, blockhash, lastValidBlockHeight);
+        return { signature };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Deposit failed';
         setError(msg);
@@ -392,7 +400,7 @@ export function useInsuranceLP(): UseInsuranceLPResult {
         const userLpAta = deriveATA(publicKey, lpMint);
 
         // 3. Build tx
-        const { blockhash } = await connection.getLatestBlockhash('confirmed');
+        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
         const tx = new Transaction({ recentBlockhash: blockhash, feePayer: publicKey });
 
         tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 150_000 }));
@@ -432,7 +440,14 @@ export function useInsuranceLP(): UseInsuranceLPResult {
         // 4. Sign + send via MWA
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
-        return { signature: results.signatures[0] };
+        const signature = results.signatures[0];
+        if (!signature) {
+          throw new Error('Withdraw signAndSend returned no signature');
+        }
+
+        // 5. Confirm the transaction landed and did not fail on-chain
+        await confirmTransactionSafe(connection, signature, blockhash, lastValidBlockHeight);
+        return { signature };
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Withdraw failed';
         setError(msg);


### PR DESCRIPTION
## Summary

- **Both `depositInsuranceLP` and `withdrawInsuranceLP` returned immediately after `signAndSend()` without confirming the transaction landed on-chain.** Users saw "success" even when transactions were dropped due to network congestion or expired blockhashes.
- Adds `confirmTransactionSafe()` calls after `signAndSend()` in both deposit and withdraw paths — matching the existing pattern in `useTrade.ts` and `useCollateral.ts`
- Destructures `lastValidBlockHeight` alongside `blockhash` from `getLatestBlockhash()` (required for slot-based TTL validation)
- Adds null-check on `signatures[0]` before passing to confirmation (guards against MWA returning empty signatures array)

## What changed

| File | Change |
|------|--------|
| `src/hooks/useInsuranceLP.ts` | Import `confirmTransactionSafe`, destructure `lastValidBlockHeight`, add signature null-check + confirmation call in both deposit & withdraw |
| `__tests__/hooks/useInsuranceLP.test.ts` | Mock `confirmTransactionSafe`, add 4 new tests: confirmation args validation + on-chain error propagation for both paths |

## Why this matters

Without transaction confirmation, the app reports success to the user after MWA signing — but the transaction may never land on-chain. This is especially dangerous for insurance LP operations where users expect their collateral to be deposited/withdrawn. On a congested network, dropped transactions would silently fail while the UI shows a success toast.

## Test plan

- [x] All 21 `useInsuranceLP` tests pass (17 existing + 4 new)
- [x] Full hook test suite passes (`useTrade`, `useCollateral`, `useStake`, `useMWA`, `usePriceStream`)
- [ ] Manual test: deposit insurance LP on devnet, verify confirmation is awaited
- [ ] Manual test: withdraw insurance LP on devnet, verify on-chain error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened transaction signature validation to ensure signatures are properly received before confirmation.
  * Enhanced error handling for on-chain transaction failures with improved error messaging.
  * Added explicit confirmation validation for deposit and withdrawal operations.

* **Tests**
  * Expanded test coverage for transaction confirmation scenarios and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->