### PR TITLE
fix(hooks): add MWA signature null-guard to useCollateral and useTrade

### DIFF
--- a/__tests__/hooks/useCollateral.test.ts
+++ b/__tests__/hooks/useCollateral.test.ts
@@ -316,3 +316,54 @@ describe('functional: deposit', () => {
     expect(mockTriggerRefresh).toHaveBeenCalledTimes(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Signature validation — MWA empty signatures guard
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('signature validation: MWA returns empty signatures', () => {
+  it('deposit returns null + error when signatures array is empty', async () => {
+    const slabData = buildSlabData({});
+    mockGetAccountInfo.mockResolvedValueOnce(makeSlabInfo(slabData));
+    mockSignAndSend.mockResolvedValueOnce({ signatures: [] });
+
+    const { result } = renderHook(() => useCollateral());
+    let res: any;
+    await act(async () => {
+      res = await result.current.deposit({
+        slabAddress: SLAB_ADDR.toBase58(),
+        amount: 50,
+        decimals: 6,
+      });
+    });
+
+    expect(res).toBeNull();
+    expect(result.current.error).toMatch(/did not return a deposit transaction signature/i);
+    expect(mockTriggerRefresh).not.toHaveBeenCalled();
+  });
+
+  it('withdraw returns null + error when signatures array is empty', async () => {
+    // Withdraw requires an existing user account on the slab (kind=0 + matching owner)
+    const WALLET_PK = new PublicKey('7nYhfGQDMFLJFJGQjz5rPpXoQiWC2iqMBfwqXVLvJCNs');
+    const slabData = buildSlabData({});
+    const ACCOUNTS_OFF = V0_ENGINE_OFF + PRE_ACCOUNTS; // 680
+    slabData[ACCOUNTS_OFF + 24] = 0; // ACCT_KIND_OFF = 24 → kind=0 (User)
+    slabData.set(WALLET_PK.toBytes(), ACCOUNTS_OFF + 184); // ACCT_OWNER_OFF = 184
+    mockGetAccountInfo.mockResolvedValueOnce(makeSlabInfo(slabData));
+    mockSignAndSend.mockResolvedValueOnce({ signatures: [] });
+
+    const { result } = renderHook(() => useCollateral());
+    let res: any;
+    await act(async () => {
+      res = await result.current.withdraw({
+        slabAddress: SLAB_ADDR.toBase58(),
+        amount: 50,
+        decimals: 6,
+      });
+    });
+
+    expect(res).toBeNull();
+    expect(result.current.error).toMatch(/did not return a withdraw transaction signature/i);
+    expect(mockTriggerRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useTrade.security.test.ts
+++ b/__tests__/hooks/useTrade.security.test.ts
@@ -362,6 +362,32 @@ describe('functional baseline', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────
+// Signature validation — MWA empty signatures guard
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('signature validation: MWA returns empty signatures', () => {
+  it('submitTrade returns null + error when signatures array is empty', async () => {
+    const slabData = buildSlabData({});
+    mockGetAccountInfo.mockResolvedValueOnce(makeSlabInfo(slabData));
+    mockSignAndSend.mockResolvedValueOnce({ signatures: [] });
+
+    const { result } = renderHook(() => useTrade());
+    let res: any;
+    await act(async () => {
+      res = await result.current.submitTrade({
+        slabAddress: SLAB_ADDR.toBase58(),
+        userIdx: 0,
+        sizeUsd: 100,
+        direction: 'long',
+      });
+    });
+
+    expect(res).toBeNull();
+    expect(result.current.error).toMatch(/did not return a trade transaction signature/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
 // LOW-7: Pyth shard_id configurable via EXPO_PUBLIC_PYTH_SHARD_ID
 // ─────────────────────────────────────────────────────────────────────────
 

--- a/src/hooks/useCollateral.ts
+++ b/src/hooks/useCollateral.ts
@@ -357,6 +357,9 @@ export function useCollateral(): UseCollateralResult {
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
         const sig = results.signatures[0];
+        if (!sig) {
+          throw new Error('Wallet did not return a deposit transaction signature');
+        }
 
         await confirmTransactionSafe(connection, sig, blockhash, lastValidBlockHeight);
         triggerRefresh();
@@ -432,6 +435,9 @@ export function useCollateral(): UseCollateralResult {
         const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
         const results = await signAndSend([new Uint8Array(serialized)]);
         const sig = results.signatures[0];
+        if (!sig) {
+          throw new Error('Wallet did not return a withdraw transaction signature');
+        }
 
         await confirmTransactionSafe(connection, sig, blockhash, lastValidBlockHeight);
         triggerRefresh();

--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -595,6 +595,9 @@ export function useTrade(): UseTradeResult {
 
         // MWA v2 returns { signatures: string[] }, not a plain array
         const sig = results.signatures[0];
+        if (!sig) {
+          throw new Error('Wallet did not return a trade transaction signature');
+        }
 
         await confirmTransactionSafe(connection, sig, blockhash, lastValidBlockHeight);
 


### PR DESCRIPTION
## Summary

- **`useCollateral` and `useTrade` pass `results.signatures[0]` directly to `confirmTransactionSafe` without null-checking.** If MWA returns an empty signatures array (user rejected, adapter timeout, etc.), `undefined` propagates to the RPC confirmation call, producing a confusing error instead of a clear failure message.
- Adds null-guard after `signAndSend()` in 3 locations: useCollateral deposit, useCollateral withdraw, useTrade submitTrade
- Matches the pattern already established in `useStake.ts` (lines 403-406, 499-502)

## What changed

| File | Change |
|------|--------|
| `src/hooks/useCollateral.ts` | Add `if (!sig) throw` after `signatures[0]` in deposit (line 360) and withdraw (line 438) |
| `src/hooks/useTrade.ts` | Add `if (!sig) throw` after `signatures[0]` in submitTrade (line 598) |
| `__tests__/hooks/useCollateral.test.ts` | 2 new tests: empty signatures → error for deposit and withdraw |
| `__tests__/hooks/useTrade.security.test.ts` | 1 new test: empty signatures → error for submitTrade |

## Why this matters

Without the guard, if a user cancels the MWA signing prompt (or the adapter times out), `undefined` gets passed as the signature to `confirmTransactionSafe → connection.confirmTransaction()`. The RPC call fails with a cryptic error like "Invalid params: Invalid" instead of a clear "Wallet did not return a transaction signature" that the catch block can surface to the user.

## Test plan

- [x] All 12 hook test suites pass (136/136 tests)
- [x] 3 new tests verify empty signatures → descriptive error for each affected path
- [ ] Manual: cancel MWA signing prompt during collateral deposit, verify clear error message
- [ ] Manual: cancel MWA signing prompt during trade, verify clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction signature validation for deposits, withdrawals, and trades. The app now validates wallet-provided signatures before attempting to confirm transactions and returns clearer error messages when signatures are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->