### PR TITLE
fix(hooks): detach WebSocket handlers on explicit disconnect

### DIFF
--- a/__tests__/hooks/usePriceStream.test.ts
+++ b/__tests__/hooks/usePriceStream.test.ts
@@ -179,6 +179,36 @@ describe('usePriceStream', () => {
     expect(ws.closed).toBe(true);
   });
 
+  it('detaches WebSocket handlers on explicit disconnect (no zombie reconnect)', () => {
+    // Regression test: previously, the async onclose callback would still
+    // fire after disconnect() and schedule a setTimeout(connect, ...) — causing
+    // a zombie reconnect timer to wake up after backgrounding/unmount and try
+    // to setState on an unmounted component (or create a duplicate connection
+    // when the app foregrounded).
+    const { unmount } = renderHook(() => usePriceStream(['slab1']));
+    const ws = MockWebSocket.latest();
+
+    act(() => { ws.onopen!(); });
+
+    // While the connection is live, handlers must be attached
+    expect(ws.onclose).not.toBeNull();
+    expect(ws.onmessage).not.toBeNull();
+
+    unmount();
+
+    // After explicit disconnect, all handlers are detached so the async
+    // onclose callback cannot schedule a reconnect.
+    expect(ws.onopen).toBeNull();
+    expect(ws.onmessage).toBeNull();
+    expect(ws.onerror).toBeNull();
+    expect(ws.onclose).toBeNull();
+    expect(ws.closed).toBe(true);
+
+    // Even if the underlying socket later fires onclose, there is no handler
+    // to receive it, so MockWebSocket.instances stays at 1 (no zombie connect)
+    expect(MockWebSocket.instances.length).toBe(1);
+  });
+
   it('batches multiple updates into single flush', async () => {
     const { result } = renderHook(() => usePriceStream(['slab1', 'slab2']));
     const ws = MockWebSocket.latest();

--- a/src/hooks/usePriceStream.ts
+++ b/src/hooks/usePriceStream.ts
@@ -218,6 +218,13 @@ export function usePriceStream(
 
   const disconnect = useCallback(() => {
     if (wsRef.current) {
+      // Detach handlers BEFORE close() so that the async onclose callback
+      // cannot schedule a zombie reconnect timer after we've cleaned up
+      // (e.g. when the app backgrounds or the component unmounts).
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onclose = null;
       wsRef.current.close();
       wsRef.current = null;
     }


### PR DESCRIPTION
## Summary

- **`disconnect()` in `usePriceStream` called `ws.close()` without detaching the `onclose` handler first.** Because `close()` is async, the `onclose` callback still fires on the next event loop tick — and its body schedules a `setTimeout(connect, ...)` for auto-reconnect.
- **Result:** a zombie reconnect timer wakes up after the app backgrounded or the component unmounted, causing either:
  - A setState on an unmounted component (React warning), or
  - A duplicate WebSocket when the app subsequently foregrounded
- The fix detaches all four handlers (`onopen`, `onmessage`, `onerror`, `onclose`) before calling `close()`. For unexpected closes (network drop while foregrounded), the handler stays attached and auto-reconnect still works as designed.

## Reproduction (before fix)

1. Open the trade screen, WebSocket connects
2. Background the app (or unmount the screen) — `disconnect()` runs, `wsRef.current = null`
3. The async `onclose` callback fires ~immediately afterward
4. It runs `reconnectTimerRef.current = setTimeout(connect, baseDelay + jitter)` — a timer in the background-ed app
5. Either: timer fires while still backgrounded → `connect()` opens a new WS even though the user isn't using the app
6. Or: app foregrounds → `handleAppState('active')` ALSO calls `connect()` → double connection

## What changed

| File | Change |
|------|--------|
| `src/hooks/usePriceStream.ts` | Detach `onopen`/`onmessage`/`onerror`/`onclose` before `close()` in `disconnect()` |
| `__tests__/hooks/usePriceStream.test.ts` | New regression test asserting all four handlers are null after unmount, and no second WebSocket instance is created |

## Test plan

- [x] All 19 `usePriceStream` tests pass (18 existing + 1 new regression test)
- [x] Full hook test suite passes (134/134 across 12 suites)
- [ ] Manual: open trade screen, background app, foreground after 5 seconds → verify only one active WebSocket connection (check Helius dashboard)
- [ ] Manual: navigate away from trade screen mid-connection → verify no React "setState on unmounted" warnings in dev console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where connection cleanup could trigger unexpected reconnection behavior.

* **Tests**
  * Added regression test to verify proper cleanup of connections when components unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->