### PR TITLE
docs: sync README setup with env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Trade coin-margined perpetuals on Solana from your phone. Connect your wallet vi
 ┌─────────────────────────────────────────┐
 │           Percolator Mobile             │
 │                                         │
-│  React Native 0.81 + Expo 54 (bare)    │
+│  React Native 0.82 + Expo 55 (bare)    │
 │                                         │
 │  ┌───────────┐  ┌───────────────────┐   │
 │  │ Screens   │  │ Solana Connection │   │
@@ -47,7 +47,7 @@ Trade coin-margined perpetuals on Solana from your phone. Connect your wallet vi
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | [React Native](https://reactnative.dev) 0.81 + [Expo](https://expo.dev) 54 (bare workflow) |
+| Framework | [React Native](https://reactnative.dev) 0.82 + [Expo](https://expo.dev) 55 (bare workflow) |
 | Language | TypeScript (strict mode) |
 | Wallet | [Solana Mobile Stack](https://solanamobile.com) — Mobile Wallet Adapter (MWA) |
 | Blockchain | [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) |
@@ -88,10 +88,18 @@ cp .env.example .env
 Edit `.env` with your configuration:
 
 ```env
-SOLANA_RPC_URL=https://api.devnet.solana.com
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ANON_KEY=your-anon-key
+EXPO_PUBLIC_API_URL=https://percolator-api-production.up.railway.app
+EXPO_PUBLIC_WEB_URL=https://percolatorlaunch.com/api
+
+EXPO_PUBLIC_HELIUS_API_KEY=YOUR_HELIUS_API_KEY_HERE
+EXPO_PUBLIC_CLUSTER=devnet
+EXPO_PUBLIC_RPC_URL=https://devnet.helius-rpc.com/?api-key=YOUR_HELIUS_API_KEY_HERE
+
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=
 ```
+```
+For local development, copy `.env.example` to `.env` and fill in your own Helius, RPC, and Supabase values. Do not commit real API keys.
 
 ### Run Development Build
 


### PR DESCRIPTION
## Summary

This PR updates the README setup instructions to match the current environment configuration and package versions.

## Changes

* Replaces outdated environment variable names with the current `EXPO_PUBLIC_*` variables.
* Adds a note to avoid committing real API keys.
* Updates the documented React Native and Expo versions.

## Why

The README currently shows older setup values, while `.env.example` and the current package configuration use updated Expo public environment variables and newer React Native / Expo versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to reflect the latest framework versions (React Native 0.82 and Expo 55), including updates to architecture diagrams and the technology stack reference section
  * Revised the environment configuration setup guide with restructured variables, updated formatting, and improved documentation to support development and deployment workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->